### PR TITLE
Fix mixup between high and low surrogate

### DIFF
--- a/src/Data/Text/Utf16.hs
+++ b/src/Data/Text/Utf16.hs
@@ -79,22 +79,22 @@ unpackUtf16 (Text u16data offset length) =
     go offset length
 
 -- | Return whether the code unit at the given index starts a surrogate pair.
--- Such a code unit must be followed by a high surrogate in valid UTF-16.
+-- Such a code unit must be followed by a low surrogate in valid UTF-16.
 -- Returns false on out of bounds indices.
-{-# INLINE isLowSurrogate #-}
-isLowSurrogate :: Int -> Text -> Bool
-isLowSurrogate !i (Text !u16data !offset !len) =
+{-# INLINE isHighSurrogate #-}
+isHighSurrogate :: Int -> Text -> Bool
+isHighSurrogate !i (Text !u16data !offset !len) =
   let
     w = indexTextArray u16data (offset + i)
   in
     i >= 0 && i < len && w >= 0xd800 && w <= 0xdbff
 
 -- | Return whether the code unit at the given index ends a surrogate pair.
--- Such a code unit must be preceded by a low surrogate in valid UTF-16.
+-- Such a code unit must be preceded by a high surrogate in valid UTF-16.
 -- Returns false on out of bounds indices.
-{-# INLINE isHighSurrogate #-}
-isHighSurrogate :: Int -> Text -> Bool
-isHighSurrogate !i (Text !u16data !offset !len) =
+{-# INLINE isLowSurrogate #-}
+isLowSurrogate :: Int -> Text -> Bool
+isLowSurrogate !i (Text !u16data !offset !len) =
   let
     w = indexTextArray u16data (offset + i)
   in
@@ -111,8 +111,8 @@ isHighSurrogate !i (Text !u16data !offset !len) =
 unsafeSliceUtf16 :: CodeUnitIndex -> CodeUnitIndex -> Text -> Text
 unsafeSliceUtf16 (CodeUnitIndex !begin) (CodeUnitIndex !length) !text
   = assert (begin + length <= TextUnsafe.lengthWord16 text)
-  $ assert (not $ isHighSurrogate begin text)
-  $ assert (not $ isLowSurrogate (begin + length - 1) text)
+  $ assert (not $ isLowSurrogate begin text)
+  $ assert (not $ isHighSurrogate (begin + length - 1) text)
   $ TextUnsafe.takeWord16 length $ TextUnsafe.dropWord16 begin text
 
 -- | The complement of `unsafeSliceUtf16`: removes the slice, and returns the
@@ -121,8 +121,8 @@ unsafeSliceUtf16 (CodeUnitIndex !begin) (CodeUnitIndex !length) !text
 unsafeCutUtf16 :: CodeUnitIndex -> CodeUnitIndex -> Text -> (Text, Text)
 unsafeCutUtf16 (CodeUnitIndex !begin) (CodeUnitIndex !length) !text
   = assert (begin + length <= TextUnsafe.lengthWord16 text)
-  $ assert (not $ isHighSurrogate begin text)
-  $ assert (not $ isLowSurrogate (begin + length - 1) text)
+  $ assert (not $ isLowSurrogate begin text)
+  $ assert (not $ isHighSurrogate (begin + length - 1) text)
     ( TextUnsafe.takeWord16 begin text
     , TextUnsafe.dropWord16 (begin + length) text
     )


### PR DESCRIPTION
This is a simple nomenclature PR that does not affect the behavior of the code.

The `isHighSurrogate` and `isLowSurrogate` function names were switched up. The `isHighSurrogate` returned `True` when the given argument was a low surrogate, and vice versa for `isLowSurrogate`. The comments also stated that low surrogates are followed by high surrogates. 

In UTF-16, high surrogates are followed by low surrogates, as explained by [unicodebook](https://unicodebook.readthedocs.io/unicode_encodings.html#utf-16-surrogate-pairs):

> [..] two 16 bits units: an high surrogate (in range U+D800—U+DBFF) followed by a low surrogate (in range U+DC00—U+DFFF)

The implementation is otherwise correct, so this pull request only changes the names and some comments.

The functions are not exported, so this change should not affect any code that depends on `Data.Text.Utf16`.