### PR TITLE
Make LLVM compilation a global setting

### DIFF
--- a/alfred-margaret.cabal
+++ b/alfred-margaret.cabal
@@ -28,6 +28,15 @@ Flag aeson
     Manual: False
     Default: True
 
+-- Compile this package with LLVM, rather than with the default code generator.
+-- LLVM produces about 20% faster code.
+Flag llvm
+  Description: Compile with LLVM
+  Manual: True
+  -- Defaulting to false makes the package buildable by Hackage,
+  -- allowing the documentation to be generated for us.
+  Default: False
+
 library
   hs-source-dirs:      src
   exposed-modules:     Data.Text.AhoCorasick.Automaton
@@ -51,6 +60,9 @@ library
   if flag(aeson) {
   build-depends:       aeson
   cpp-options:         -DHAS_AESON
+  }
+  if flag(llvm) {
+  ghc-options:         -fllvm -optlo=-O3 -optlo=-tailcallelim
   }
 
 test-suite test-suite

--- a/alfred-margaret.cabal
+++ b/alfred-margaret.cabal
@@ -55,7 +55,7 @@ library
                      , text
                      , unordered-containers
                      , vector
-  ghc-options:         -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns
+  ghc-options:         -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns -O2
   default-language:    Haskell2010
   if flag(aeson) {
   build-depends:       aeson

--- a/src/Data/Text/AhoCorasick/Automaton.hs
+++ b/src/Data/Text/AhoCorasick/Automaton.hs
@@ -4,12 +4,6 @@
 -- Licensed under the 3-clause BSD license, see the LICENSE file in the
 -- repository root.
 
--- Compile this module with LLVM, rather than with the default code generator.
--- LLVM produces about 20% faster code.
--- We pass -fignore-asserts to improve performance: we ran this code with
--- asserts enabled in production for two months, and in this time, the asserts
--- have not been violated.
-{-# OPTIONS_GHC -fllvm -O2 -optlo=-O3 -optlo=-tailcallelim -fignore-asserts #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric #-}

--- a/src/Data/Text/AhoCorasick/Replacer.hs
+++ b/src/Data/Text/AhoCorasick/Replacer.hs
@@ -4,8 +4,6 @@
 -- Licensed under the 3-clause BSD license, see the LICENSE file in the
 -- repository root.
 
--- See Automaton.hs for why these GHC flags are here.
-{-# OPTIONS_GHC -fllvm -O2 -optlo=-O3 -optlo=-tailcallelim -fignore-asserts #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveAnyClass #-}

--- a/src/Data/Text/AhoCorasick/Searcher.hs
+++ b/src/Data/Text/AhoCorasick/Searcher.hs
@@ -4,11 +4,6 @@
 -- Licensed under the 3-clause BSD license, see the LICENSE file in the
 -- repository root.
 
--- See AhoCorasick.Automaton for more info about these GHC flags.
--- TL;DR: They make things faster, and we need the flags here because the
--- functions from that module may be inlined into this module.
-{-# OPTIONS_GHC -fllvm -O2 -optlo=-O3 -optlo=-tailcallelim -fignore-asserts #-}
-
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric #-}

--- a/src/Data/Text/BoyerMoore/Automaton.hs
+++ b/src/Data/Text/BoyerMoore/Automaton.hs
@@ -4,9 +4,6 @@
 -- Licensed under the 3-clause BSD license, see the LICENSE file in the
 -- repository root.
 
--- Compile this module with LLVM, rather than with the default code generator.
--- LLVM produces about 20% faster code.
-{-# OPTIONS_GHC -fllvm -O2 -optlo=-O3 -optlo=-tailcallelim -fignore-asserts #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric #-}

--- a/src/Data/Text/BoyerMoore/Replacer.hs
+++ b/src/Data/Text/BoyerMoore/Replacer.hs
@@ -4,11 +4,6 @@
 -- Licensed under the 3-clause BSD license, see the LICENSE file in the
 -- repository root.
 
--- See Data.Text.AhoCorasick.Automaton for more info about these GHC flags.
--- TL;DR: They make things faster, and we need the flags here because the
--- functions from that module may be inlined into this module.
-{-# OPTIONS_GHC -fllvm -O2 -optlo=-O3 -optlo=-tailcallelim -fignore-asserts #-}
-
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
 

--- a/src/Data/Text/BoyerMoore/Searcher.hs
+++ b/src/Data/Text/BoyerMoore/Searcher.hs
@@ -4,11 +4,6 @@
 -- Licensed under the 3-clause BSD license, see the LICENSE file in the
 -- repository root.
 
--- See Data.Text.AhoCorasick.Automaton for more info about these GHC flags.
--- TL;DR: They make things faster, and we need the flags here because the
--- functions from that module may be inlined into this module.
-{-# OPTIONS_GHC -fllvm -O2 -optlo=-O3 -optlo=-tailcallelim -fignore-asserts #-}
-
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}

--- a/src/Data/Text/Utf16.hs
+++ b/src/Data/Text/Utf16.hs
@@ -9,7 +9,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# OPTIONS_GHC -fllvm -O2 -optlo=-O3 -optlo=-tailcallelim -fignore-asserts #-}
 
 -- | This module provides functions that allow treating Text values as series of Utf16 codepoints
 -- instead of characters.


### PR DESCRIPTION
1. It cannot be forgotten in individual modules this way
2. The library is easier to integrate when LLVM is not available (with the hard-coded OPTIONS_GHC, there's not much one can do besides forking)
3. It is easy to turn on LLVM when needed