### PR TITLE
Add version bounds 

### DIFF
--- a/alfred-margaret.cabal
+++ b/alfred-margaret.cabal
@@ -47,18 +47,19 @@ library
                      , Data.Text.BoyerMoore.Replacer
                      , Data.Text.BoyerMoore.Searcher
                      , Data.Text.Utf16
-  build-depends:       base >= 4.7 && < 5
-                     , containers
-                     , deepseq
-                     , hashable
-                     , primitive
-                     , text
-                     , unordered-containers
-                     , vector
+  build-depends:
+      base             >= 4.7 && < 5
+    , containers       >= 0.6 && < 0.7
+    , deepseq          >= 1.4 && < 1.5
+    , hashable         >= 1.2.7 && < 1.4
+    , primitive        >= 0.6.4 && < 0.8
+    , text             >= 1.2.3 && < 1.3
+    , unordered-containers >= 0.2.9 && < 0.3
+    , vector           >= 0.12 && < 0.13
   ghc-options:         -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns -O2
   default-language:    Haskell2010
   if flag(aeson) {
-  build-depends:       aeson
+  build-depends:       aeson >= 1.4.2 && < 1.6
   cpp-options:         -DHAS_AESON
   }
   if flag(llvm) {

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,11 @@
 resolver: lts-16.18
 packages:
 - .
+
+# Note: This section will be ignored by stack, on non-NixOS systems.
+# It can be explicitly enabled on non-NixOS systems by passing --nix.
+# On NixOS this section is needed to bring the non-Haskell dependencies
+# into scope.
+nix:
+  packages:
+    - zlib


### PR DESCRIPTION
This PR adds version bounds, so that we can upload the package to Hackage.

The bounds were generated with `cabal gen-bounds` and then manually widened.