### PR TITLE
Case-Insensitive UTF-8 Implementation of Aho-Corasick on ByteArray

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -198,6 +198,12 @@ steps:
   # Remove trailing whitespace
   - trailing_whitespace: {}
 
+  - module_header:
+      indent: 4
+      sort: true
+      break_where: exports
+      open_bracket: next_line
+
 # A common setting is the number of columns (parts of) code will be wrapped
 # to. Different steps take this into account. Default: 80.
 columns: 100

--- a/alfred-margaret.cabal
+++ b/alfred-margaret.cabal
@@ -46,6 +46,7 @@ library
                      , Data.Text.BoyerMoore.Automaton
                      , Data.Text.BoyerMoore.Replacer
                      , Data.Text.BoyerMoore.Searcher
+                     , Data.Text.CaseSensitivity
                      , Data.Text.Utf16
                      , Data.Text.Utf8
                      , Data.Text.Utf8.AhoCorasick.Automaton
@@ -58,6 +59,8 @@ library
     , text             >= 1.2.3 && < 1.3
     , unordered-containers >= 0.2.9 && < 0.3
     , vector           >= 0.12 && < 0.13
+    -- TODO: Remove bytestring once we move to text-2.0
+    , bytestring
   ghc-options:         -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns -O2
   default-language:    Haskell2010
   if flag(aeson) {

--- a/benchmark/.gitignore
+++ b/benchmark/.gitignore
@@ -1,8 +1,15 @@
 data/*.txt
+data-utf8/*.txt
 !data/example.txt
+!data-utf8/example.txt
 data/*.tar.xz
 *.stats
 *.results
+*.aux
+*.hp
+*.pdf
+*.prof
+*.ps
 
 java/bazel-bin
 java/bazel-genfiles

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -22,13 +22,13 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 
 The first part of this file defines the search terms (the "needles") `Lorem`, `sunt` and `officia`.
 The second part, after a blank line, defines the corpus to search in  (the "haystack").
-Currently, these files **must be encoded as UTF-16**.
+Currently, these files **must be encoded as UTF-16 Little-Endian without BOM**.
 
 Each run of `benchmark.py` generates a pair for `.results` and `.stats` files.
 
 ### Python
 
-Run the benchmark in this directory
+Run the benchmark in this directory:
 
 ```
 ./benchmark.py ./naive.py --prefix python
@@ -78,7 +78,7 @@ Run the benchmark using the compiled binary:
 
 ### Haskell, UTF-8 Version
 
-In `text-2.0` and above, the `Text` type with use UTF-8 under the hood.
+In `text-2.0` and above, the `Text` type will use UTF-8 under the hood.
 The `haskell-utf8` directory contains a preliminary benchmark for `alfred-margaret` using UTF-8 byte arrays.
 To compile it, run Stack in the `haskell-utf8` directory:
 
@@ -89,7 +89,15 @@ stack build
 Run the benchmark using the compiled binary:
 
 ```
-./benchmark.py haskell-utf8/.stack-work/dist/*/Cabal-3.0.1.0/build/ac-bench/ac-bench --prefix haskell-utf8
+./benchmark.py haskell-utf8/.stack-work/dist/*/Cabal-3.0.1.0/build/ac-bench/ac-bench --prefix haskell-utf8 --data-directory data-utf8
+```
+
+Note that you must first convert the data files for the benchmark into UTF-8 and put them in `data-utf8`.
+You can use `iconv` for this:
+
+```
+mkdir data-utf8
+for f in $(ls data); do echo $f; iconv -f UTF-16LE -t UTF-8 data/$f -o data-utf8/$f; done
 ```
 
 ## Inspecting the Results

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 
 # clize turns this into a CLI where program is a required argument and prefix is a required option
-def benchmark(program, *, prefix):
+def benchmark(program, *, prefix, data_directory="data"):
     """
     This script runs an executable 5 times and collects the running times it
     reports. Names of the .txt files in the data/ directory are provivided to the
@@ -21,6 +21,7 @@ def benchmark(program, *, prefix):
 
     :param program: What to benchmark.
     :param prefix: Used for generating output files $prefix.{stats,results}
+    :param data_directory: Directory containing the benchmark data files.
     """
 
     # # Disable automatic CPU frequency scaling to get lower variance measurements.
@@ -33,10 +34,13 @@ def benchmark(program, *, prefix):
         sys.exit(1)
 
     input_file_names = []
-    for f in os.listdir('data'):
-        file_name = f'data/{f}'
+    for f in os.listdir(data_directory):
+        file_name = os.path.join(data_directory, f)
         if os.path.isfile(file_name) and file_name.endswith('.txt'):
             input_file_names.append(os.path.abspath(file_name))
+    
+    # Makes comparison of .results files easier
+    input_file_names.sort()
 
     print(f'Found {len(input_file_names)} files to benchmark.')
 

--- a/benchmark/data-utf8/example.txt
+++ b/benchmark/data-utf8/example.txt
@@ -1,0 +1,11 @@
+Henk
+Piet
+Klaas
+Sjaak
+Marieke
+
+Henk eet een appel en Piet eet kaas.
+Klaas eet ook kaas.
+Kaas is baas.
+Mari en Marieke wandelen door het bos.
+De auto van Sjaak heeft geen trekhaak en die van Klaas ook niet.

--- a/benchmark/haskell-utf8/app/Main.hs
+++ b/benchmark/haskell-utf8/app/Main.hs
@@ -10,10 +10,6 @@ import Data.Foldable (for_, traverse_)
 import System.IO (hPrint, stderr, stdout)
 import Text.Printf (hPrintf)
 
-import qualified Data.ByteString as BS
-import qualified Data.List as List
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Encoding
 import qualified System.Clock as Clock
 import qualified System.Environment as Env
 
@@ -26,19 +22,8 @@ main = Env.getArgs >>= traverse_ processFile
 
 processFile :: FilePath -> IO ()
 processFile path = do
-  -- Decode UTF-16 input files
-  inputLines <- Text.lines . Encoding.decodeUtf16LE <$> BS.readFile path
-  let (needles', haystackLines) = List.break Text.null inputLines
-  -- Turn the haystack into a UTF-8 byte array using String as an intermediate representation
-  -- Not the nicest solution but it works well enough until we convert the dataset into UTF-8.
-  -- haystackLines also contains the empty line we breaked on, drop it using tail
-  let !haystack = Utf8.pack $ Text.unpack $ Text.unlines $ tail haystackLines
-  -- Turn each needle into a UTF-8 byte array.
-  let !needles = map (Utf8.pack . Text.unpack) needles'
-
-  -- ByteArray has no NFData instance :(
-  -- void $ evaluate $ force needles
-  -- void $ evaluate $ force haystack
+  -- TODO: Revert once we have text-2.0
+  (needles, haystack) <- readNeedleHaystackFile path
 
   for_ [0 :: Int .. 5] $ \i -> do
     (count, duration) <- acBench needles haystack
@@ -46,6 +31,22 @@ processFile path = do
       hPrint stderr count
     hPrintf stdout "%d\t" (Clock.toNanoSecs duration)
   hPrintf stdout "\n"
+
+readNeedleHaystackFile :: FilePath -> IO ([Utf8.Text], Utf8.Text)
+readNeedleHaystackFile path = do
+  (Utf8.Text u8data off len) <- Utf8.readFile path
+  pure $ go u8data off len []
+  where
+    go u8data off 0 needles = (reverse needles, Utf8.Text u8data off 0)
+    go u8data off len needles
+      -- "line starts with newline char" ==> empty line, emit haystack as slice of u8data
+      | Utf8.indexTextArray u8data off == 10 = (reverse needles, Utf8.Text u8data (off + 1) (len - 1))
+      | otherwise = consumeNeedle u8data off len needles off
+
+    consumeNeedle u8data off len needles needleStart
+      -- Newline ==> emit needle as slice of u8data
+      | Utf8.indexTextArray u8data off == 10 = go u8data (off + 1) (len - 1) $ Utf8.Text u8data needleStart (off - needleStart) : needles
+      | otherwise = consumeNeedle u8data (off + 1) (len - 1) needles needleStart
 
 acBench :: [Utf8.Text] -> Utf8.Text -> IO (Int, Clock.TimeSpec)
 {-# NOINLINE acBench #-}

--- a/src/Data/Text/AhoCorasick/Automaton.hs
+++ b/src/Data/Text/AhoCorasick/Automaton.hs
@@ -6,9 +6,7 @@
 
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | An efficient implementation of the Aho-Corasick string matching algorithm.
@@ -29,49 +27,34 @@
 -- automaton as int maps, which are convenient for incremental construction.
 -- Afterwards we pack the automaton into unboxed vectors.
 module Data.Text.AhoCorasick.Automaton
-  ( AcMachine (..)
-  , build
-  , runText
-  , runLower
-  , debugBuildDot
-  , CaseSensitivity (..)
-  , CodeUnitIndex (..)
-  , Match (..)
-  , Next (..)
-  )
-  where
+    ( AcMachine (..)
+    , CaseSensitivity (..)
+    , CodeUnitIndex (..)
+    , Match (..)
+    , Next (..)
+    , build
+    , debugBuildDot
+    , runLower
+    , runText
+    ) where
 
 import Prelude hiding (length)
 
 import Control.DeepSeq (NFData)
 import Data.Bits (shiftL, shiftR, (.&.), (.|.))
 import Data.Foldable (foldl')
-import Data.Hashable (Hashable)
 import Data.IntMap.Strict (IntMap)
 import Data.Text.Internal (Text (..))
 import Data.Word (Word64)
 import GHC.Generics (Generic)
-
-#if defined(HAS_AESON)
-import Data.Aeson (FromJSON, ToJSON)
-#endif
 
 import qualified Data.IntMap.Strict as IntMap
 import qualified Data.List as List
 import qualified Data.Vector as Vector
 import qualified Data.Vector.Unboxed as UVector
 
+import Data.Text.CaseSensitivity (CaseSensitivity (..))
 import Data.Text.Utf16 (CodeUnit, CodeUnitIndex (..), indexTextArray, lowerCodeUnit)
-
-data CaseSensitivity
-  = CaseSensitive
-  | IgnoreCase
-  deriving stock (Eq, Generic, Show)
-#if defined(HAS_AESON)
-  deriving anyclass (Hashable, NFData, FromJSON, ToJSON)
-#else
-  deriving anyclass (Hashable, NFData)
-#endif
 
 -- | A numbered state in the Aho-Corasick automaton.
 type State = Int

--- a/src/Data/Text/BoyerMoore/Automaton.hs
+++ b/src/Data/Text/BoyerMoore/Automaton.hs
@@ -22,19 +22,16 @@
 -- The algorithm here can be potentially improved by including the Galil rule
 -- (https://en.wikipedia.org/wiki/Boyer%E2%80%93Moore_string-search_algorithm#The_Galil_rule)
 module Data.Text.BoyerMoore.Automaton
-  (
-    Automaton
-  , CaseSensitivity (..)
-  , buildAutomaton
-  , runText
-  , runLower
-  , patternLength
-  , patternText
-
-  , CodeUnitIndex (..)
-  , Next (..)
-  )
-  where
+    ( Automaton
+    , CaseSensitivity (..)
+    , CodeUnitIndex (..)
+    , Next (..)
+    , buildAutomaton
+    , patternLength
+    , patternText
+    , runLower
+    , runText
+    ) where
 
 import Prelude hiding (length)
 
@@ -52,7 +49,8 @@ import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Vector.Unboxed as UVector
 import qualified Data.Vector.Unboxed.Mutable as UMVector
 
-import Data.Text.AhoCorasick.Automaton (CaseSensitivity (..), Next (..))
+import Data.Text.AhoCorasick.Automaton (Next (..))
+import Data.Text.CaseSensitivity (CaseSensitivity (..))
 import Data.Text.Utf16 (CodeUnit, CodeUnitIndex (..), lengthUtf16, lowerCodeUnit, unsafeIndexUtf16)
 
 -- | A Boyer-Moore automaton is based on lookup-tables that allow skipping through the haystack.

--- a/src/Data/Text/CaseSensitivity.hs
+++ b/src/Data/Text/CaseSensitivity.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+
+module Data.Text.CaseSensitivity where
+
+import Control.DeepSeq (NFData)
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Hashable (Hashable)
+import GHC.Generics (Generic)
+
+data CaseSensitivity
+  = CaseSensitive
+  | IgnoreCase
+  deriving stock (Eq, Generic, Show)
+#if defined(HAS_AESON)
+  deriving anyclass (Hashable, NFData, FromJSON, ToJSON)
+#else
+  deriving anyclass (Hashable, NFData)
+#endif

--- a/tests/Data/Text/Utf8/AhoCorasickSpec.hs
+++ b/tests/Data/Text/Utf8/AhoCorasickSpec.hs
@@ -9,11 +9,10 @@
 
 module Data.Text.Utf8.AhoCorasickSpec where
 
-import Data.Primitive (ByteArray, byteArrayFromList)
+import Data.Primitive (byteArrayFromList)
 import Data.String (IsString, fromString)
 import qualified Data.Text.Utf8 as Utf8
 import qualified Data.Text.Utf8.AhoCorasick.Automaton as Aho
-import Data.Word (Word8)
 import Test.Hspec (Expectation, Spec, describe, it, shouldBe)
 
 spec :: Spec
@@ -27,10 +26,24 @@ spec = do
         it "encodes Hwair" $ utf8Test "𐍈" [0xf0, 0x90, 0x8d, 0x88]
         it "encodes all of the above" $ utf8Test "$€£𐍈" [0x24, 0xe2, 0x82, 0xac, 0xc2, 0xa3, 0xf0, 0x90, 0x8d, 0x88]
 
-    describe "runText" $ do
+    describe "case sensitive search" $ do
         describe "countMatches" $ do
             it "counts the right number of matches in a basic example" $ do
-                countMatches ["abc", "rst", "xyz"] "abcdefghijklmnopqrstuvwxyz" `shouldBe` 3
+                countMatches Aho.CaseSensitive ["abc", "rst", "xyz"] "abcdefghijklmnopqrstuvwxyz" `shouldBe` 3
+
+            it "counts the right number of matches in an example with 1-, 2-, 3- and 4-code unit code points" $ do
+                countMatches Aho.CaseSensitive ["$", "£"] "$€£𐍈" `shouldBe` 2
+
+    describe "case insensitive search" $ do
+        describe "countMatches" $ do
+            it "counts the right number of matches in a basic example" $ do
+                countMatches Aho.IgnoreCase ["abc", "rst", "xyz"] "abcdefghijklmnopqrstuvwxyz" `shouldBe` 3
+
+            it "does not work with uppercase needles" $ do
+                countMatches Aho.IgnoreCase ["ABC", "Rst", "xYZ"] "abcdefghijklmnopqrstuvwxyz" `shouldBe` 0
+
+            it "works with characters that are not in ASCII" $ do
+                countMatches Aho.IgnoreCase ["groß", "öffnung", "tür"] "Großfräsmaschinenöffnungstür" `shouldBe` 3
 
 -- helpers
 
@@ -41,13 +54,13 @@ utf8Test :: String -> [Utf8.CodeUnit] -> Expectation
 utf8Test str byteList = fromString str `shouldBe` Utf8.Text (byteArrayFromList byteList) 0 (length byteList)
 
 -- From ./benchmark
-countMatches :: [Utf8.Text] -> Utf8.Text -> Int
+countMatches :: Aho.CaseSensitivity -> [Utf8.Text] -> Utf8.Text -> Int
 {-# NOINLINE countMatches #-}
-countMatches needles haystack = case needles of
+countMatches caseSensitivity needles haystack = case needles of
   [] -> 0
   _  ->
     let
       ac = Aho.build $ zip (map Utf8.unpackUtf8 needles) (repeat ())
       onMatch !n _match = Aho.Step (n + 1)
     in
-      Aho.runText 0 onMatch ac haystack
+      Aho.runWithCase caseSensitivity 0 onMatch ac haystack


### PR DESCRIPTION
## Current State

- Added `runWithCase` to `Data.Text.Utf8.AhoCorasick.Automaton` with the same signature as the same function in `Data.Text.AhoCorasick.Automaton`.
- Compatible with UTF-16 version (reports the same results for our benchmark).
- Current benchmark results (for `runLower`, i.e. code points are lowercased on the fly):

```
haskell.stats:
  mean time: 5.036 ± 0.048 seconds
   min time: 4.730 seconds

haskell-utf8.stats:
  mean time: 13.836 ± 0.247 seconds
   min time: 13.293 seconds
```

## Tasks

- [x] Lowercase 1 byte, 2 byte and 3 byte code points in `runLower`
- [x] Run benchmark, compare to `runText` implementation and UTF-16 version:
  - Currently around 3x slower compared to the UTF-16 `runLower` version on our benchmark.
  - Might be because in the UTF-8 version, not all function calls are tail calls so far. Needs further investigation.
- [x] Merge `runText` and `runLower` into `runWithCase` as in the UTF-16 version. Run benchmark to ensure that performance does not regress.
  - See note above. Not all functions in `runWithCase` are tail calls (yet?), that might be why it's slower. Needs further investigation.
- [x] Ensure that every function has at least the same level of comments as its corresponding function in the UTF-16 version.