### PR TITLE
UTF-8 performance improvements

### DIFF
--- a/alfred-margaret.cabal
+++ b/alfred-margaret.cabal
@@ -50,6 +50,7 @@ library
                      , Data.Text.Utf16
                      , Data.Text.Utf8
                      , Data.Text.Utf8.AhoCorasick.Automaton
+                     , Data.TypedByteArray
   build-depends:
       base             >= 4.7 && < 5
     , containers       >= 0.6 && < 0.7

--- a/src/Data/TypedByteArray.hs
+++ b/src/Data/TypedByteArray.hs
@@ -1,0 +1,24 @@
+-- Alfred-Margaret: Fast Aho-Corasick string searching
+-- Copyright 2022 Channable
+--
+-- Licensed under the 3-clause BSD license, see the LICENSE file in the
+-- repository root.
+
+module Data.TypedByteArray
+    ( TypedByteArray
+    , fromList
+    , unsafeIndex
+    ) where
+
+import Data.Primitive (ByteArray, Prim, byteArrayFromList, indexByteArray)
+
+-- | Thin wrapper around 'ByteArray' that makes signatures and indexing nicer to read.
+newtype TypedByteArray a = TypedByteArray ByteArray
+
+fromList :: Prim a => [a] -> TypedByteArray a
+fromList = TypedByteArray . byteArrayFromList
+
+-- | Element index without bounds checking.
+{-# INLINE unsafeIndex #-}
+unsafeIndex :: Prim a => TypedByteArray a -> Int -> a
+unsafeIndex (TypedByteArray arr) = indexByteArray arr


### PR DESCRIPTION
## Current state

- Use Unicode code points (21 bits) at automaton transitions
  - This way we don't need to re-encode code points after decoding and lowercasing the input stream.
- Add some bang patterns
  - In our inner loop, some arguments were being unboxed and reboxed in each iteration, causing a significant allocation overhead.
- Replace unboxed vectors by primitive `ByteArrays`
  - Surprisingly, this eliminated a somewhat significant overhead for indexing.

## To Do

- [x] Post current benchmark results here for comparison
- [x] Add warnings for future implementors where appropriate