### PR TITLE
UTF-8 Aho-Corasick library code

### DIFF
--- a/alfred-margaret.cabal
+++ b/alfred-margaret.cabal
@@ -52,6 +52,9 @@ library
                      , Data.Text.Utf16
                      , Data.Text.Utf8
                      , Data.Text.Utf8.AhoCorasick.Automaton
+                     , Data.Text.Utf8.AhoCorasick.Replacer
+                     , Data.Text.Utf8.AhoCorasick.Searcher
+                     , Data.Text.Utf8.AhoCorasick.Splitter
                      , Data.TypedByteArray
   build-depends:
       base             >= 4.7 && < 5

--- a/benchmark/haskell-utf8/app/Main.hs
+++ b/benchmark/haskell-utf8/app/Main.hs
@@ -5,7 +5,9 @@
 -- | Benchmark for our Aho-Corasick implementation.
 module Main where
 
+import Control.DeepSeq (force)
 import Control.Exception (evaluate)
+import Control.Monad (void, when)
 import Data.Foldable (for_, traverse_)
 import System.IO (hPrint, stderr, stdout)
 import Text.Printf (hPrintf)
@@ -13,7 +15,6 @@ import Text.Printf (hPrintf)
 import qualified System.Clock as Clock
 import qualified System.Environment as Env
 
-import Control.Monad (when)
 import qualified Data.Text.Utf8 as Utf8
 import qualified Data.Text.Utf8.AhoCorasick.Automaton as Aho
 
@@ -24,6 +25,9 @@ processFile :: FilePath -> IO ()
 processFile path = do
   -- TODO: Revert once we have text-2.0
   (needles, haystack) <- readNeedleHaystackFile path
+
+  void $ evaluate $ force needles
+  void $ evaluate $ force haystack
 
   for_ [0 :: Int .. 5] $ \i -> do
     (count, duration) <- acBench needles haystack

--- a/src/Data/Text/Utf8/AhoCorasick/Automaton.hs
+++ b/src/Data/Text/Utf8/AhoCorasick/Automaton.hs
@@ -5,6 +5,7 @@
 -- repository root.
 
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | An efficient implementation of the Aho-Corasick string matching algorithm.
@@ -40,11 +41,13 @@ module Data.Text.Utf8.AhoCorasick.Automaton
     , runWithCase
     ) where
 
+import Control.DeepSeq (NFData)
 import Data.Bits (Bits (shiftL, shiftR, (.&.), (.|.)))
 import Data.Char (chr)
 import Data.Foldable (foldl')
 import Data.IntMap.Strict (IntMap)
 import Data.Word (Word32, Word64)
+import GHC.Generics (Generic)
 
 import qualified Data.Char as Char
 import qualified Data.IntMap.Strict as IntMap
@@ -52,7 +55,8 @@ import qualified Data.List as List
 import qualified Data.Vector as Vector
 
 import Data.Text.CaseSensitivity (CaseSensitivity (..))
-import Data.Text.Utf8 (CodeUnit, CodeUnitIndex (CodeUnitIndex), Text (..), indexTextArray)
+import Data.Text.Utf8 (CodePoint, CodeUnit, CodeUnitIndex (CodeUnitIndex), Text (..),
+                       indexTextArray)
 import Data.TypedByteArray (Prim, TypedByteArray)
 
 import qualified Data.Text.Utf8 as Utf8
@@ -110,9 +114,9 @@ data AcMachine v = AcMachine
   -- ^ A lookup table for transitions from the root state, an optimization to
   -- avoid having to walk all transitions, at the cost of using a bit of
   -- additional memory.
-  }
+  } deriving (Generic)
 
-type CodePoint = Int
+instance NFData v => NFData (AcMachine v)
 
 -- AUTOMATON CONSTRUCTION
 
@@ -237,16 +241,7 @@ type ValuesMap v = IntMap [v]
 
 -- | Build the trie of the Aho-Corasick state machine for all input needles.
 buildTransitionMap :: forall v. [([CodeUnit], v)] -> (Int, TransitionMap, ValuesMap v)
-buildTransitionMap needles = buildTransitionMap' [(decodeUtf8 cus, val) | (cus, val) <- needles]
-
--- | Decode a list of UTF-8 code units into a list of code points.
-decodeUtf8 :: [CodeUnit] -> [CodePoint]
-decodeUtf8 [] = []
-decodeUtf8 (cu0 : cus) | cu0 < 0xc0 = fromIntegral cu0 : decodeUtf8 cus
-decodeUtf8 (cu0 : cu1 : cus) | cu0 < 0xe0 = Utf8.decode2 cu0 cu1 : decodeUtf8 cus
-decodeUtf8 (cu0 : cu1 : cu2 : cus) | cu0 < 0xf0 = Utf8.decode3 cu0 cu1 cu2 : decodeUtf8 cus
-decodeUtf8 (cu0 : cu1 : cu2 : cu3 : cus) = Utf8.decode4 cu0 cu1 cu2 cu3 : decodeUtf8 cus
-decodeUtf8 cus = error $ "Invalid UTF-8 input sequence at " ++ show (take 4 cus)
+buildTransitionMap needles = buildTransitionMap' [(Utf8.decodeUtf8 cus, val) | (cus, val) <- needles]
 
 buildTransitionMap' :: forall v. [([CodePoint], v)] -> (Int, TransitionMap, ValuesMap v)
 buildTransitionMap' =

--- a/src/Data/Text/Utf8/AhoCorasick/Replacer.hs
+++ b/src/Data/Text/Utf8/AhoCorasick/Replacer.hs
@@ -1,0 +1,219 @@
+-- Alfred-Margaret: Fast Aho-Corasick string searching
+-- Copyright 2019 Channable
+--
+-- Licensed under the 3-clause BSD license, see the LICENSE file in the
+-- repository root.
+
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+
+-- | Implements sequential string replacements based on the Aho-Corasick algorithm.
+module Data.Text.Utf8.AhoCorasick.Replacer
+    ( -- * State machine
+      Needle
+    , Payload (..)
+    , Replacement
+    , Replacer (..)
+    , build
+    , compose
+    , run
+    , runWithLimit
+    ) where
+
+import Control.DeepSeq (NFData)
+import Data.Hashable (Hashable)
+import Data.List (sort)
+import Data.Maybe (fromJust)
+import GHC.Generics (Generic)
+
+#if defined(HAS_AESON)
+import qualified Data.Aeson as AE
+#endif
+
+import Data.Text.CaseSensitivity (CaseSensitivity (..))
+import Data.Text.Utf8 (CodeUnitIndex, Text)
+import Data.Text.Utf8.AhoCorasick.Searcher (Searcher)
+
+import qualified Data.Text.Utf8 as Utf8
+import qualified Data.Text.Utf8.AhoCorasick.Automaton as Aho
+import qualified Data.Text.Utf8.AhoCorasick.Searcher as Searcher
+
+-- | Descriptive type alias for strings to search for.
+type Needle = Text
+
+-- | Descriptive type alias for replacements.
+type Replacement = Text
+
+-- | Priority of a needle. Higher integers indicate higher priorities.
+-- Replacement order is such that all matches of priority p are replaced before
+-- replacing any matches of priority q where p > q.
+type Priority = Int
+
+data Payload = Payload
+  { needlePriority    :: {-# UNPACK #-} !Priority
+  , needleLength      :: {-# UNPACK #-} !CodeUnitIndex
+  , needleReplacement :: !Replacement
+  }
+#if defined(HAS_AESON)
+  deriving (Eq, Generic, Hashable, NFData, Show, AE.FromJSON, AE.ToJSON)
+#else
+  deriving (Eq, Generic, Hashable, NFData, Show)
+#endif
+
+-- | A state machine used for efficient replacements with many different needles.
+data Replacer = Replacer
+  { replacerCaseSensitivity :: CaseSensitivity
+  , replacerSearcher :: Searcher Payload
+  }
+  deriving stock (Show, Eq, Generic)
+#if defined(HAS_AESON)
+  deriving (Hashable, NFData, AE.FromJSON, AE.ToJSON)
+#else
+  deriving (Hashable, NFData)
+#endif
+
+-- | Build an Aho-Corasick automaton that can be used for performing fast
+-- sequential replaces.
+--
+-- Case-insensitive matching performs per-letter language-agnostic lower-casing.
+-- Therefore, it will work in most cases, but not in languages where lower-casing
+-- depends on the context of the character in question.
+--
+-- We need to revisit this algorithm when we want to implement full Unicode
+-- support.
+build :: CaseSensitivity -> [(Needle, Replacement)] -> Replacer
+build caseSensitivity replaces = Replacer caseSensitivity searcher
+  where
+    searcher = Searcher.buildWithValues caseSensitivity $ zipWith mapNeedle [0..] replaces
+    mapNeedle i (needle, replacement) =
+      let
+        needle' = case caseSensitivity of
+          CaseSensitive -> needle
+          IgnoreCase -> Utf8.lowerUtf8 needle
+      in
+        -- Note that we negate i: earlier needles have a higher priority. We
+        -- could avoid it and define larger integers to be lower priority, but
+        -- that made the terminology in this module very confusing.
+        (needle', Payload (-i) (Utf8.lengthUtf8 needle') replacement)
+
+-- | Return the composition `replacer2` after `replacer1`, if they have the same
+-- case sensitivity. If the case sensitivity differs, Nothing is returned.
+compose :: Replacer -> Replacer -> Maybe Replacer
+compose (Replacer case1 searcher1) (Replacer case2 searcher2)
+  | case1 /= case2 = Nothing
+  | otherwise =
+      let
+        -- Replace the priorities of the second machine, so they all come after
+        -- the first.
+        renumber i (needle, Payload _ len replacement) = (needle, Payload (-i) len replacement)
+        needles1 = Searcher.needles searcher1
+        needles2 = Searcher.needles searcher2
+        searcher = Searcher.buildWithValues case1 $ zipWith renumber [0..] (needles1 ++ needles2)
+      in
+        Just $ Replacer case1 searcher
+
+-- A match collected while running replacements. It is isomorphic to the Match
+-- reported by the automaton, but the data is arranged in a more useful way:
+-- as the start index and length of the match, and the replacement.
+data Match = Match !CodeUnitIndex !CodeUnitIndex !Text deriving (Eq, Ord, Show)
+
+-- | Apply replacements of all matches. Assumes that the matches are ordered by
+-- match position, and that no matches overlap.
+replace :: [Match] -> Text -> Text
+replace matches haystack = Utf8.concat $ go 0 matches haystack
+  where
+    -- At every match, cut the string into three pieces, removing the match.
+    -- Because a Text is a buffer pointer and (offset, length), cutting does not
+    -- involve string copies. Only at the very end we piece together the strings
+    -- again, so Text can allocate a buffer of the right length and memcpy the
+    -- parts into the new target string.
+    -- If `k` is a code unit index into the original text, then `k - offset`
+    -- is an index into `remainder`. In other words, `offset` is the index into
+    -- the original text where `remainder` starts.
+    go :: CodeUnitIndex -> [Match] -> Text -> [Text]
+    go !_offset [] remainder = [remainder]
+    go !offset ((Match pos len replacement) : ms) remainder =
+      let
+        (prefix, suffix) = Utf8.unsafeCutUtf8 (pos - offset) len remainder
+      in
+        prefix : replacement : go (pos + len) ms suffix
+
+-- | Compute the length of the string resulting from applying the replacements.
+replacementLength :: [Match] -> Text -> CodeUnitIndex
+replacementLength matches initial  = go matches (Utf8.lengthUtf8 initial)
+  where
+    go [] !acc = acc
+    go (Match _ matchLen repl : rest) !acc = go rest (acc - matchLen + Utf8.lengthUtf8 repl)
+
+-- | Given a list of matches sorted on start position, remove matches that start
+-- within an earlier match.
+removeOverlap :: [Match] -> [Match]
+removeOverlap matches = case matches of
+  [] -> []
+  [m] -> [m]
+  (m0@(Match pos0 len0 _) : m1@(Match pos1 _ _) : ms) ->
+    if pos1 >= pos0 + len0
+      then m0 : removeOverlap (m1:ms)
+      else removeOverlap (m0:ms)
+
+-- | When we iterate through all matches, keep track only of the matches with
+-- the highest priority: those are the ones that we will replace first. If we
+-- find multiple matches with that priority, remember all of them. If we find a
+-- match with lower priority, ignore it, because we already have a more
+-- important match. Also, if the priority is `threshold` or higher, ignore the
+-- match, so we can exclude matches if we already did a round of replacements
+-- for that priority. This way we don't have to build a new automaton after
+-- every round of replacements.
+{-# INLINE prependMatch #-}
+prependMatch :: Priority -> (Priority, [Match]) -> Aho.Match Payload -> Aho.Next (Priority, [Match])
+prependMatch !threshold (!pBest, !matches) (Aho.Match pos (Payload pMatch len replacement))
+  | pMatch < threshold && pMatch >  pBest = Aho.Step (pMatch, [Match (pos - len) len replacement])
+  | pMatch < threshold && pMatch == pBest = Aho.Step (pMatch, Match (pos - len) len replacement : matches)
+  | otherwise = Aho.Step (pBest, matches)
+
+run :: Replacer -> Text -> Text
+run replacer = fromJust . runWithLimit replacer maxBound
+
+{-# NOINLINE runWithLimit #-}
+runWithLimit :: Replacer -> CodeUnitIndex -> Text -> Maybe Text
+runWithLimit (Replacer case_ searcher) maxLength = go initialThreshold
+  where
+    !automaton = Searcher.automaton searcher
+
+    -- Priorities are 0 or lower, so an initial threshold of 1 keeps all
+    -- matches.
+    !initialThreshold = 1
+
+    -- Needle priorities go from 0 for the highest priority to (-numNeedles + 1)
+    -- for the lowest priority. That means that if we find a match with
+    -- minPriority, we don't need to do another pass afterwards, because there
+    -- are no remaining needles.
+    !minPriority = 1 - Searcher.numNeedles searcher
+
+    go :: Priority -> Text -> Maybe Text
+    go !threshold haystack =
+      let
+        seed = (minBound :: Priority, [])
+        matchesWithPriority = case case_ of
+          CaseSensitive -> Aho.runText seed (prependMatch threshold) automaton haystack
+          IgnoreCase -> Aho.runLower seed (prependMatch threshold) automaton haystack
+      in
+        case matchesWithPriority of
+          -- No match at the given threshold, there is nothing left to do.
+          -- Return the input string unmodified.
+          (_, []) -> Just haystack
+          -- We found matches at priority p. Remove overlapping matches, then
+          -- apply all replacements. Next, we need to go again, this time
+          -- considering only needles with a lower priority than p. As an
+          -- optimization (which matters mainly for the single needle case),
+          -- if we find a match at the lowest priority, we don't need another
+          -- pass. Note that if in `rawMatches` we find only matches of priority
+          -- p > minPriority, then we do still need another pass, because the
+          -- replacements could create new matches.
+          (p, matches)
+            | replacementLength matches haystack > maxLength -> Nothing
+            | p == minPriority -> Just $ replace (removeOverlap $ sort matches) haystack
+            | otherwise -> go p $ replace (removeOverlap $ sort matches) haystack

--- a/src/Data/Text/Utf8/AhoCorasick/Searcher.hs
+++ b/src/Data/Text/Utf8/AhoCorasick/Searcher.hs
@@ -1,0 +1,155 @@
+-- Alfred-Margaret: Fast Aho-Corasick string searching
+-- Copyright 2022 Channable
+--
+-- Licensed under the 3-clause BSD license, see the LICENSE file in the
+-- repository root.
+
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections #-}
+
+module Data.Text.Utf8.AhoCorasick.Searcher
+    ( Searcher
+    , automaton
+    , build
+    , buildWithValues
+    , caseSensitivity
+    , containsAny
+    , needles
+    , numNeedles
+    , setSearcherCaseSensitivity
+    ) where
+
+import Control.DeepSeq (NFData)
+import Data.Hashable (Hashable (hashWithSalt), Hashed, hashed, unhashed)
+import GHC.Generics (Generic)
+
+#if defined(HAS_AESON)
+import Data.Aeson ((.:), (.=))
+import qualified Data.Aeson as AE
+#endif
+
+import Data.Text.CaseSensitivity (CaseSensitivity (..))
+import Data.Text.Utf8 (Text)
+
+import qualified Data.Text.Utf8 as Utf8
+import qualified Data.Text.Utf8.AhoCorasick.Automaton as Aho
+
+-- | A set of needles with associated values, and an Aho-Corasick automaton to
+-- efficiently find those needles.
+--
+-- INVARIANT: searcherAutomaton = Aho.build . searcherNeedles
+-- To enforce this invariant, the fields are not exposed from this module.
+-- There is a separate constructor function.
+--
+-- The purpose of this wrapper is to have a type that is Hashable and Eq, so we
+-- can derive those for types that embed the searcher, whithout requiring the
+-- automaton itself to be Hashable or Eq, which would be both wasteful and
+-- tedious. Because the automaton is fully determined by the needles and
+-- associated values, it is sufficient to implement Eq and Hashable in terms of
+-- the needles only.
+--
+-- We also use Hashed to cache the hash of the needles.
+data Searcher v = Searcher
+  { searcherCaseSensitive :: CaseSensitivity
+  , searcherNeedles :: Hashed [(Text, v)]
+  , searcherNumNeedles :: Int
+  , searcherAutomaton :: Aho.AcMachine v
+  } deriving (Generic)
+
+#if defined(HAS_AESON)
+instance AE.ToJSON v => AE.ToJSON (Searcher v) where
+  toJSON s = AE.object
+    [ "needles" .= needles s
+    , "caseSensitivity" .= caseSensitivity s
+    ]
+
+instance (Hashable v, AE.FromJSON v) => AE.FromJSON (Searcher v) where
+  parseJSON = AE.withObject "Searcher" $ \o -> buildWithValues <$> o .: "caseSensitivity" <*> o .: "needles"
+#endif
+
+instance Show (Searcher v) where
+  show _ = "Searcher _ _ _"
+
+instance Hashable v => Hashable (Searcher v) where
+  hashWithSalt salt searcher = hashWithSalt salt $ searcherNeedles searcher
+  {-# INLINE hashWithSalt #-}
+
+instance Eq v => Eq (Searcher v) where
+  -- Since we store the length of the needle list anyway,
+  -- we can use it to early out if there is a length mismatch.
+  Searcher cx xs nx _ == Searcher cy ys ny _ = (nx, xs, cx) == (ny, ys, cy)
+  {-# INLINE (==) #-}
+
+instance NFData v => NFData (Searcher v)
+
+-- NOTE: Although we could implement Semigroup for every v by just concatenating
+-- needle lists, we don't, because this might lead to unexpected results. For
+-- example, if v is (Int, a) where the Int is a priority, combining two
+-- searchers might want to discard priorities, concatenate the needle lists, and
+-- reassign priorities, rather than concatenating the needle lists as-is and
+-- possibly having duplicate priorities in the resulting searcher.
+instance Semigroup (Searcher ()) where
+  x <> y
+    | caseSensitivity x == caseSensitivity y
+      = buildWithValues (searcherCaseSensitive x) (needles x <> needles y)
+    | otherwise = error "Combining searchers of different case sensitivity"
+  {-# INLINE (<>) #-}
+
+-- | Builds the Searcher for a list of needles
+-- The caller is responsible that the needles are lower case in case the IgnoreCase
+-- is used for case sensitivity
+build :: CaseSensitivity -> [Text] -> Searcher ()
+build case_ = buildWithValues case_ . fmap (, ())
+
+-- | The caller is responsible that the needles are lower case in case the IgnoreCase
+-- is used for case sensitivity
+buildWithValues :: Hashable v => CaseSensitivity -> [(Text, v)] -> Searcher v
+{-# INLINABLE buildWithValues #-}
+buildWithValues case_ ns =
+  let
+    unpack (text, value) = (Utf8.unpackUtf8 text, value)
+  in
+    Searcher case_ (hashed ns) (length ns) $ Aho.build $ fmap unpack ns
+
+needles :: Searcher v -> [(Text, v)]
+needles = unhashed . searcherNeedles
+
+numNeedles :: Searcher v -> Int
+numNeedles = searcherNumNeedles
+
+automaton :: Searcher v -> Aho.AcMachine v
+automaton = searcherAutomaton
+
+caseSensitivity :: Searcher v -> CaseSensitivity
+caseSensitivity = searcherCaseSensitive
+
+-- | Updates the case sensitivity of the searcher. Does not change the
+-- capitilization of the needles. The caller should be certain that if IgnoreCase
+-- is passed, the needles are already lower case.
+setSearcherCaseSensitivity :: CaseSensitivity -> Searcher v -> Searcher v
+setSearcherCaseSensitivity case_ searcher = searcher{
+    searcherCaseSensitive = case_
+  }
+
+-- | Return whether the haystack contains any of the needles.
+-- Case sensitivity depends on the properties of the searcher
+-- This function is marked noinline as an inlining boundary. Aho.runText is
+-- marked inline, so this function will be optimized to report only whether
+-- there is a match, and not construct a list of matches. We don't want this
+-- function be inline, to make sure that the conditions of the caller don't
+-- affect how this function is optimized. There is little to gain from
+-- additional inlining. The pragma is not an optimization in itself, rather it
+-- is a defence against fragile optimizer decisions.
+{-# NOINLINE containsAny #-}
+containsAny :: Searcher () -> Text -> Bool
+containsAny !searcher !text =
+  let
+    -- On the first match, return True immediately.
+    f _acc _match = Aho.Done True
+  in case caseSensitivity searcher of
+    CaseSensitive  -> Aho.runText False f (automaton searcher) text
+    IgnoreCase      -> Aho.runLower False f (automaton searcher) text

--- a/src/Data/Text/Utf8/AhoCorasick/Splitter.hs
+++ b/src/Data/Text/Utf8/AhoCorasick/Splitter.hs
@@ -1,0 +1,189 @@
+-- Alfred-Margaret: Fast Aho-Corasick string searching
+-- Copyright 2019 Channable
+--
+-- Licensed under the 3-clause BSD license, see the LICENSE file in the
+-- repository root.
+
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
+
+-- | Splitting strings using Aho–Corasick.
+module Data.Text.Utf8.AhoCorasick.Splitter
+    ( Splitter
+    , automaton
+    , build
+    , separator
+    , split
+    , splitIgnoreCase
+    , splitReverse
+    , splitReverseIgnoreCase
+    ) where
+
+import Control.DeepSeq (NFData (..))
+import Data.Function (on)
+import Data.Hashable (Hashable (..))
+import Data.List.NonEmpty (NonEmpty ((:|)))
+import Data.Text.Utf8 (Text)
+
+#if defined(HAS_AESON)
+import qualified Data.Aeson as AE
+#endif
+
+import qualified Data.List.NonEmpty as NonEmpty
+
+import Data.Text.Utf8.AhoCorasick.Automaton (AcMachine)
+
+import qualified Data.Text.Utf8 as Utf8
+import qualified Data.Text.Utf8.AhoCorasick.Automaton as Aho
+
+--------------------------------------------------------------------------------
+-- Splitter
+
+-- | Build a splitter once, then use it many times!
+data Splitter =
+  Splitter
+    { splitterAutomaton :: AcMachine () -- INVARIANT: Exactly one needle.
+    , splitterSeparator :: Text         -- INVARIANT: Equivalent to needle.
+    }
+
+#if defined(HAS_AESON)
+instance AE.ToJSON Splitter where
+  toJSON = AE.toJSON . separator
+
+instance AE.FromJSON Splitter where
+  parseJSON v = build <$> AE.parseJSON v
+#endif
+
+-- | Construct a splitter with a single separator.
+{-# INLINE build #-}
+build :: Text -> Splitter
+build sep =
+  let !auto = Aho.build [(Utf8.unpackUtf8 sep, ())] in
+  Splitter auto sep
+
+-- | Get the automaton that would be used for finding separators.
+{-# INLINE automaton #-}
+automaton :: Splitter -> AcMachine ()
+automaton = splitterAutomaton
+
+-- | What is the separator we are splitting on?
+{-# INLINE separator #-}
+separator :: Splitter -> Text
+separator = splitterSeparator
+
+-- | Split the given string into strings separated by the separator.
+--
+-- If the order of the results is not important, use the faster function
+-- 'splitReverse' instead.
+{-# INLINE split #-}
+split :: Splitter -> Text -> NonEmpty Text
+split = (NonEmpty.reverse .) . splitReverse
+
+-- | Split the given string into strings separated by the separator.
+--
+-- If the order of the results is not important, use the faster function
+-- 'splitReverseIgnoreCase' instead.
+--
+-- The separator is matched case-insensitively, but the splitter must have been
+-- constructed with a lowercase needle.
+{-# INLINE splitIgnoreCase #-}
+splitIgnoreCase :: Splitter -> Text -> NonEmpty Text
+splitIgnoreCase = (NonEmpty.reverse .) . splitReverseIgnoreCase
+
+-- | Like 'split', but return the substrings in reverse order.
+{-# INLINE splitReverse #-}
+splitReverse :: Splitter -> Text -> NonEmpty Text
+splitReverse s t =
+  finalizeAccum $
+    Aho.runText
+      (zeroAccum (separator s) t)
+      stepAccum
+      (automaton s)
+      t
+
+-- | Like 'splitIgnoreCase', but return the substrings in reverse order.
+{-# INLINE splitReverseIgnoreCase #-}
+splitReverseIgnoreCase :: Splitter -> Text -> NonEmpty Text
+splitReverseIgnoreCase s t =
+  finalizeAccum $
+    Aho.runLower
+      (zeroAccum (separator s) t)
+      stepAccum
+      (automaton s)
+      t
+
+--------------------------------------------------------------------------------
+-- Fold
+
+-- | The accumulator is used as state when processing the matches from left to
+-- right. While the matches are fed to us ordered by end offset, all matches
+-- have the same length because there is only one needle.
+data Accum =
+  Accum
+    { _accumSepLen   :: !Aho.CodeUnitIndex -- ^ Length of separator.
+    , _accumHaystack :: !Text              -- ^ Haystack to slice off of.
+    , accumResult    :: ![Text]            -- ^ Match-separated strings.
+    , accumPrevEnd   :: !Aho.CodeUnitIndex -- ^ Offset at end of last match.
+    }
+
+-- | Finalizing the accumulator does more than just 'accumResult', hence this
+-- is a separate function.
+{-# INLINE finalizeAccum #-}
+finalizeAccum :: Accum -> NonEmpty Text
+finalizeAccum (Accum _ hay res prevEnd) =
+  -- Once we have processed all the matches, there is still the substring after
+  -- the final match. This substring is always included in the result, even
+  -- when there were no matches. Hence we can return a non-empty list.
+  let !str = Utf8.unsafeSliceUtf8 prevEnd (Utf8.lengthUtf8 hay - prevEnd) hay in
+  str :| res
+
+-- | The initial accumulator begins at the begin of the haystack.
+{-# INLINE zeroAccum #-}
+zeroAccum :: Text -> Text -> Accum
+zeroAccum sep hay = Accum (Utf8.lengthUtf8 sep) hay [] 0
+
+-- | Step the accumulator using the next match. Overlapping matches will be
+-- ignored. Overlapping matches may occur when the separator has a non-empty
+-- prefix that is also a suffix.
+{-# INLINE stepAccum #-}
+stepAccum :: Accum -> Aho.Match v -> Aho.Next Accum
+stepAccum acc@(Accum sepLen hay res prevEnd) (Aho.Match sepEnd _)
+
+  -- When the match begins before the current offset, it overlaps a match that
+  -- we processed before, and so we ignore it.
+  | sepEnd - sepLen < prevEnd =
+      Aho.Step acc
+
+  -- The match is behind the current offset, so we slice the haystack until the
+  -- begin of the match and include that as a result.
+  | otherwise =
+      let !str = Utf8.unsafeSliceUtf8 prevEnd (sepEnd - sepLen - prevEnd) hay in
+      Aho.Step acc { accumResult = str : res, accumPrevEnd = sepEnd }
+
+--------------------------------------------------------------------------------
+-- Instances
+
+instance Eq Splitter where
+  {-# INLINE (==) #-}
+  (==) = (==) `on` separator
+
+instance Ord Splitter where
+  {-# INLINE compare #-}
+  compare = compare `on` separator
+
+instance Hashable Splitter where
+  {-# INLINE hashWithSalt #-}
+  hashWithSalt salt searcher =
+    salt `hashWithSalt` separator searcher
+
+instance NFData Splitter where
+  {-# INLINE rnf #-}
+  rnf (Splitter searcher sepLength) =
+    rnf searcher `seq`
+    rnf sepLength
+
+instance Show Splitter where
+  showsPrec p splitter =
+    showParen (p > 10) $
+      showString "build " .
+        showsPrec 11 (separator splitter)

--- a/tests/Data/Text/AhoCorasickSpec.hs
+++ b/tests/Data/Text/AhoCorasickSpec.hs
@@ -7,7 +7,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Data.Text.AhoCorasickSpec (spec) where
+module Data.Text.AhoCorasickSpec
+    ( spec
+    ) where
 
 import Control.DeepSeq (rnf)
 import Control.Monad (forM_, unless)

--- a/tests/Data/Text/Orphans.hs
+++ b/tests/Data/Text/Orphans.hs
@@ -4,7 +4,13 @@ import Test.QuickCheck (Arbitrary (..))
 
 import qualified Test.QuickCheck.Gen as Gen
 
-import Data.Text.AhoCorasick.Automaton (CaseSensitivity (..))
+import Data.Text.Utf8 as Utf8
+
+import Data.Text.CaseSensitivity (CaseSensitivity (..))
 
 instance Arbitrary CaseSensitivity where
   arbitrary = Gen.elements [CaseSensitive, IgnoreCase]
+
+-- TODO: Slow placeholder implementation until we can use text-2.0
+instance Arbitrary Utf8.Text where
+  arbitrary = fmap Utf8.pack arbitrary

--- a/tests/Data/Text/Utf8/AhoCorasickSpec.hs
+++ b/tests/Data/Text/Utf8/AhoCorasickSpec.hs
@@ -9,24 +9,40 @@
 
 module Data.Text.Utf8.AhoCorasickSpec where
 
+import Control.Monad (forM_)
+import Data.Foldable (foldl')
+import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.Primitive (byteArrayFromList)
 import Data.String (IsString, fromString)
+import Test.Hspec (Expectation, Spec, describe, it, shouldBe)
+import Test.Hspec.QuickCheck (modifyMaxSize, prop)
+import Test.QuickCheck (Arbitrary (arbitrary, shrink), forAll, forAllShrink)
+
+import qualified Data.Text as T
+import qualified Test.QuickCheck.Gen as Gen
+
+import Data.Text.Orphans ()
+
 import qualified Data.Text.Utf8 as Utf8
 import qualified Data.Text.Utf8.AhoCorasick.Automaton as Aho
-import Test.Hspec (Expectation, Spec, describe, it, shouldBe)
+import qualified Data.Text.Utf8.AhoCorasick.Replacer as Replacer
+import qualified Data.Text.Utf8.AhoCorasick.Searcher as Searcher
+import qualified Data.Text.Utf8.AhoCorasick.Splitter as Splitter
 
 spec :: Spec
 spec = do
     -- Ensure that helper functions are actually helping
     -- Examples are from https://en.wikipedia.org/wiki/UTF-8
     describe "IsString ByteArray" $ do
+
         it "encodes the dollar sign" $ utf8Test "$" [0x24]
         it "encodes the euro sign" $ utf8Test "€" [0xe2, 0x82, 0xac]
         it "encodes the pound sign" $ utf8Test "£" [0xc2, 0xa3]
         it "encodes Hwair" $ utf8Test "𐍈" [0xf0, 0x90, 0x8d, 0x88]
         it "encodes all of the above" $ utf8Test "$€£𐍈" [0x24, 0xe2, 0x82, 0xac, 0xc2, 0xa3, 0xf0, 0x90, 0x8d, 0x88]
 
-    describe "case sensitive search" $ do
+    describe "runText" $ do
+
         describe "countMatches" $ do
             it "counts the right number of matches in a basic example" $ do
                 countMatches Aho.CaseSensitive ["abc", "rst", "xyz"] "abcdefghijklmnopqrstuvwxyz" `shouldBe` 3
@@ -34,7 +50,8 @@ spec = do
             it "counts the right number of matches in an example with 1-, 2-, 3- and 4-code unit code points" $ do
                 countMatches Aho.CaseSensitive ["$", "£"] "$€£𐍈" `shouldBe` 2
 
-    describe "case insensitive search" $ do
+    describe "runLower" $ do
+
         describe "countMatches" $ do
             it "counts the right number of matches in a basic example" $ do
                 countMatches Aho.IgnoreCase ["abc", "rst", "xyz"] "abcdefghijklmnopqrstuvwxyz" `shouldBe` 3
@@ -44,6 +61,136 @@ spec = do
 
             it "works with characters that are not in ASCII" $ do
                 countMatches Aho.IgnoreCase ["groß", "öffnung", "tür"] "Großfräsmaschinenöffnungstür" `shouldBe` 3
+
+    describe "Seacher" $ do
+
+        describe "containsAny" $ do
+
+            it "gives the right values for the examples in the README" $ do
+                let needles = ["tshirt", "shirts", "shorts"]
+                let searcher = Searcher.build Aho.CaseSensitive needles
+
+                Searcher.containsAny searcher "short tshirts" `shouldBe` True
+                Searcher.containsAny searcher "long shirt" `shouldBe` False
+                Searcher.containsAny searcher "Short TSHIRTS" `shouldBe` False
+
+                let searcher' = Searcher.build Aho.IgnoreCase needles
+
+                Searcher.containsAny searcher' "Short TSHIRTS" `shouldBe` True
+
+            it "works with the the first line of the illiad" $ do
+                let illiad = "Ἄνδρα μοι ἔννεπε, Μοῦσα, πολύτροπον, ὃς μάλα πολλὰ"
+                    needleSets = [(["μοι"], True), (["Ὀδυσεύς"], False)]
+
+                forM_ needleSets $ \(needles, expectedResult) -> do
+                    let searcher = Searcher.build Aho.CaseSensitive needles
+                    Searcher.containsAny searcher illiad `shouldBe` expectedResult
+
+    modifyMaxSize (const 10) $ describe "Replacer" $ do
+
+        describe "run" $ do
+            let
+                genHaystack = fmap Utf8.pack $ Gen.listOf $ Gen.frequency [(40, Gen.elements "abAB"), (1, pure 'İ'), (1, arbitrary)]
+
+                -- needles may not be empty, because empty needles are filtered out in an I.ActionReplaceMultiple
+                genNeedle = fmap Utf8.pack $ Gen.resize 3 $ Gen.listOf1 $ Gen.elements "abAB"
+                genReplaces = Gen.listOf $ (,) <$> genNeedle <*> arbitrary
+                shrinkReplaces = filter (not . any (\(needle, _) -> Utf8.null needle)) . shrink
+
+                replace needles haystack =
+                    Replacer.run (Replacer.build Aho.CaseSensitive needles) haystack
+
+                replaceIgnoreCase needles haystack =
+                    Replacer.run (Replacer.build Aho.IgnoreCase needles) haystack
+
+            it "replaces all occurrences" $ do
+                replace [("A", "B")] "AXAXB" `shouldBe` "BXBXB"
+                replace [("A", "B"), ("X", "Y")] "AXAXB" `shouldBe` "BYBYB"
+                replace [("aaa", ""), ("b", "c")] "aaabaaa" `shouldBe` "c"
+                -- Have a few non-matching needles too.
+                replace [("A", "B"), ("Q", "r"), ("Z", "")] "AXAXB" `shouldBe` "BXBXB"
+
+            it "replaces only non-overlapping matches" $ do
+                replace [("aa", "zz"), ("bb", "w")] "aaabbb" `shouldBe` "zzawb"
+                replace [("aaa", "")] "aaaaa" `shouldBe` "aa"
+
+            it "replaces all occurrences in priority order" $ do
+                replace [("A", ""), ("BBBB", "bingo")] "BBABB" `shouldBe` "bingo"
+                replace [("BB", ""), ("BBBB", "bingo")] "BBBB" `shouldBe` ""
+
+            it "replaces needles that contain a surrogate pair" $
+                replace [("\x1f574", "levitating man in business suit")]
+                    "the \x1f574" `shouldBe` "the levitating man in business suit"
+
+
+            it "replaces all occurrences case-insensitively" $ do
+                replaceIgnoreCase [("A", "B")] "AXAXB" `shouldBe` "BXBXB"
+                replaceIgnoreCase [("A", "B")] "axaxb" `shouldBe` "BxBxb"
+                replaceIgnoreCase [("a", "b")] "AXAXB" `shouldBe` "bXbXB"
+
+                replaceIgnoreCase [("A", "B"), ("X", "Y")] "AXAXB" `shouldBe` "BYBYB"
+                replaceIgnoreCase [("A", "B"), ("X", "Y")] "axaxb" `shouldBe` "BYBYb"
+                replaceIgnoreCase [("a", "b"), ("x", "y")] "AXAXB" `shouldBe` "bybyB"
+
+            it "matches replacements case-insensitively" $
+              replaceIgnoreCase [("foo", "BAR"), ("bar", "BAZ")] "Foo" `shouldBe` "BAZ"
+
+            it "matches replacements case-insensitively for non-ascii characters" $ do
+                replaceIgnoreCase [("éclair", "lightning")] "Éclair" `shouldBe` "lightning"
+                -- Note: U+0319 is an uppercase alpha, which looks exactly like A, but it
+                -- is a different code point.
+                replaceIgnoreCase [("bèta", "α"), ("\x0391", "alpha")] "BÈTA" `shouldBe` "alpha"
+
+            it "matches surrogate pairs case-insensitively" $ do
+                -- We can't lowercase a levivating man in business suit, but that should
+                -- not affect whether we match it or not.
+                replaceIgnoreCase [("\x1f574", "levitating man in business suit")] "the \x1f574"
+                    `shouldBe` "the levitating man in business suit"
+
+            prop "satisfies (run . compose a b) == (run b (run a))" $
+                forAllShrink genHaystack shrink $ \haystack ->
+                forAll arbitrary $ \case_ ->
+                forAllShrink genReplaces shrinkReplaces $ \replaces1 ->
+                forAllShrink genReplaces shrinkReplaces $ \replaces2 ->
+                let
+                    rm1 = Replacer.build case_ replaces1
+                    rm2 = Replacer.build case_ replaces2
+                    Just rm12 = Replacer.compose rm1 rm2
+                in
+                    Replacer.run rm2 (Replacer.run rm1 haystack)
+                    `shouldBe` Replacer.run rm12 haystack
+
+            prop "is identity for empty needles" $ \case_ haystack ->
+                let replacerId = Replacer.build case_ []
+                in Replacer.run replacerId haystack `shouldBe` haystack
+
+            -- TODO: Uncomment when we have text-2.0
+            prop "is equivalent to sequential Text.replace calls" $
+                forAllShrink genHaystack shrink $ \haystack ->
+                forAllShrink genReplaces shrinkReplaces $ \replaces ->
+                let
+                    replacer = Replacer.build Aho.CaseSensitive replaces
+                    -- TODO: Remove conversions once we move to text-2.0
+                    replaceText agg (needle, replacement) = Utf8.pack $ T.unpack $ T.replace (T.pack $ Utf8.unpack needle) (T.pack $ Utf8.unpack replacement) (T.pack $ Utf8.unpack agg)
+                    expected = foldl' replaceText haystack replaces
+                in
+                    Replacer.run replacer haystack `shouldBe` expected
+
+    describe "Splitter" $ do
+
+        describe "split" $ do
+
+            it "passes an example" $ do
+                let separator = "bob"
+                    splitter = Splitter.build separator
+
+                Splitter.split splitter "C++bobobCOBOLbobScala" `shouldBe` "C++" :| ["obCOBOL", "Scala"]
+
+            it "neatly splits the first line of the illiad" $ do
+                let splitter = Splitter.build ", "
+
+                Splitter.split splitter "Ἄνδρα μοι ἔννεπε, Μοῦσα, πολύτροπον, ὃς μάλα πολλὰ" `shouldBe`
+                    "Ἄνδρα μοι ἔννεπε" :| ["Μοῦσα", "πολύτροπον", "ὃς μάλα πολλὰ"]
 
 -- helpers
 

--- a/tests/Data/Text/Utf8/Utf8Spec.hs
+++ b/tests/Data/Text/Utf8/Utf8Spec.hs
@@ -1,13 +1,23 @@
+{-# LANGUAGE ScopedTypeVariables #-}
 module Data.Text.Utf8.Utf8Spec where
 
 import Control.Monad (forM_)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck (Arbitrary (arbitrary), choose)
+
 import qualified Data.Char as Char
-import Test.Hspec (Spec, describe, it, shouldSatisfy)
+
+import Data.Text.Utf8 (stringToByteArray)
+
+import qualified Data.Text.Utf8 as Utf8
 
 spec :: Spec
 spec = do
     describe "Properties of the BMP in UTF-8" $ do
+
         describe "Char.toLower" $ do
+
             {-
             it "does not generate common suffixes" $ do
                 forM_ bmpCodepoints $ flip shouldSatisfy $ \cp ->
@@ -22,16 +32,54 @@ spec = do
                 forM_ bmpCodepoints $ flip shouldSatisfy $ \cp ->
                     mapCp Char.toLower cp == mapCp (Char.toLower . Char.toLower) cp
 
+    describe "toLowerAscii" $ do
+
+        it "is equivalent to Char.toLower on ASCII" $ do
+
+            forM_ [0..0x7f] $ flip shouldSatisfy $ \cp ->
+                mapCp Char.toLower cp == Utf8.toLowerAscii cp
+
+    describe "slicing functions" $ do
+
+        it "satisfies the example in Data.Text.Utf8" $ do
+            let begin = Utf8.CodeUnitIndex 2
+            let length_   = Utf8.CodeUnitIndex 6
+            Utf8.unsafeSliceUtf8 begin length_ slicingExample `shouldBe` Utf8.pack "DEFGHI"
+            Utf8.unsafeCutUtf8 begin length_ slicingExample `shouldBe` (Utf8.pack "BC", Utf8.pack "JKL")
+
+        prop "unsafeSliceUtf8 and unsafeCutUtf8 are complementary" $ \ (SlicingExampleIndices begin length_ :: SlicingExampleIndices) -> do
+            let (prefix, suffix) = Utf8.unsafeCutUtf8 begin length_ slicingExample
+            Utf8.concat [prefix, Utf8.unsafeSliceUtf8 begin length_ slicingExample, suffix] `shouldBe` slicingExample
+
+
+-- | Example shown in section "Slicing Functions" in 'Data.Text.Utf8".
+slicingExample :: Utf8.Text
+slicingExample = Utf8.Text (stringToByteArray "ABCDEFGHIJKLMN") 1 11
+
+data SlicingExampleIndices = SlicingExampleIndices Utf8.CodeUnitIndex Utf8.CodeUnitIndex
+    deriving Show
+
+instance Arbitrary SlicingExampleIndices where
+    arbitrary = do
+        let exampleLength = unCodeUnitIndex $ Utf8.lengthUtf8 slicingExample
+
+        begin <- choose (0, exampleLength)
+        length_ <- choose (0, exampleLength - begin)
+
+        pure $ SlicingExampleIndices (Utf8.CodeUnitIndex begin) (Utf8.CodeUnitIndex length_)
+
+        where unCodeUnitIndex (Utf8.CodeUnitIndex i) = i
+
 -- | The Basic Multilingual Plane (BMP) contains the Unicode code points
 -- 0x0000 through 0xFFFF.
 bmpCodepoints :: [Int]
-bmpCodepoints = [0..0x10000]
+bmpCodepoints = [0..0xffff]
 
 mapCp :: (Char -> Char) -> Int -> Int
 mapCp f = Char.ord . f . Char.chr
 
 commonSuffix :: Eq a => [a] -> [a] -> [a]
-commonSuffix xs ys = reverse $ go (reverse xs) (reverse ys)
+commonSuffix list list' = reverse $ go (reverse list) (reverse list')
     where
         go (x:xs) (y:ys)
             | x == y = x : go xs ys

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -12,4 +12,4 @@ main = hspec $ do
   describe "Data.Text.AhoCorasick" A.spec
   describe "Data.Text.BoyerMoore" B.spec
   describe "Data.Text.Utf8.AhoCorasick" U8A.spec
-  describe "Data.Text.Utf8.Utf8" U8.spec
+  describe "Data.Text.Utf8" U8.spec


### PR DESCRIPTION
Since the UTF-8 implementation of the Aho-Corasick algorithm works now, we can start to port the remaining library code.

- [x] `Data.Text.Utf8.AhoCorasick.Searcher`
- [x] `Data.Text.Utf8.AhoCorasick.Splitter`
- [x] `Data.Text.Utf8.AhoCorasick.Replacer`