### PR TITLE
containsAll function for Boyer-Moore modules

### DIFF
--- a/src/Data/Text/BoyerMoore/Searcher.hs
+++ b/src/Data/Text/BoyerMoore/Searcher.hs
@@ -9,18 +9,17 @@
 {-# LANGUAGE FlexibleInstances #-}
 
 module Data.Text.BoyerMoore.Searcher
-  ( Searcher
-  , build
-  , buildWithValues
-  , needles
-  , numNeedles
-  , automata
-  , caseSensitivity
-  , containsAny
-  , setSearcherCaseSensitivity
-  )
-  where
-
+    ( Searcher
+    , automata
+    , build
+    , buildWithValues
+    , caseSensitivity
+    , containsAll
+    , containsAny
+    , needles
+    , numNeedles
+    , setSearcherCaseSensitivity
+    ) where
 
 import Control.DeepSeq (NFData)
 import Data.Bifunctor (first)
@@ -123,3 +122,13 @@ containsAny !searcher !text =
         any (\(automaton, ()) -> BoyerMoore.runText False f automaton text) (automata searcher)
       IgnoreCase ->
         any (\(automaton, ()) -> BoyerMoore.runLower False f automaton text) (automata searcher)
+
+-- | Like 'containsAny', but checks whether all needles match instead.
+{-# NOINLINE containsAll #-}
+containsAll :: Searcher () -> Text -> Bool
+containsAll !searcher !text =
+  let
+    -- On the first match, return True immediately.
+    f _acc _match = BoyerMoore.Done True
+  in
+    all (\(automaton, ()) -> BoyerMoore.runText False f automaton text) (automata searcher)

--- a/src/Data/Text/Utf8/BoyerMoore/Searcher.hs
+++ b/src/Data/Text/Utf8/BoyerMoore/Searcher.hs
@@ -13,6 +13,7 @@ module Data.Text.Utf8.BoyerMoore.Searcher
     , automata
     , build
     , buildWithValues
+    , containsAll
     , containsAny
     , needles
     , numNeedles
@@ -101,3 +102,13 @@ containsAny !searcher !text =
     f _acc _match = BoyerMoore.Done True
   in
     any (\(automaton, ()) -> BoyerMoore.runText False f automaton text) (automata searcher)
+
+-- | Like 'containsAny', but checks whether all needles match instead.
+{-# NOINLINE containsAll #-}
+containsAll :: Searcher () -> Text -> Bool
+containsAll !searcher !text =
+  let
+    -- On the first match, return True immediately.
+    f _acc _match = BoyerMoore.Done True
+  in
+    all (\(automaton, ()) -> BoyerMoore.runText False f automaton text) (automata searcher)

--- a/tests/Data/Text/Utf8/BoyerMooreSpec.hs
+++ b/tests/Data/Text/Utf8/BoyerMooreSpec.hs
@@ -251,3 +251,12 @@ spec = parallel $ modifyMaxSuccess (const 200) $ do
             not (Text.null needle) && needle `Text.isInfixOf` haystack
         in
           Searcher.containsAny searcher haystack `shouldBe` any test needles
+
+    describe "containsAll" $ do
+      prop "is equivalent to conjunction of Text.isInfixOf calls*" $ \ (needles :: [Text]) (haystack :: Text) ->
+        let
+          searcher = Searcher.build needles
+          test needle =
+            not (Text.null needle) && needle `Text.isInfixOf` haystack
+        in
+          Searcher.containsAll searcher haystack `shouldBe` all test needles


### PR DESCRIPTION
While I added `containsAll` functions to the Aho-Corasick modules in #33, they were still missing from our Boyer-Moore modules. This PR adds `Data.Text.{,Utf8.}BoyerMoore.Searcher.containsAll` and corresponding unit tests.