### PR TITLE
Make Boyer-Moore containsAll functions use Searcher Int

### DIFF
--- a/src/Data/Text/Utf8/BoyerMoore/Searcher.hs
+++ b/src/Data/Text/Utf8/BoyerMoore/Searcher.hs
@@ -12,6 +12,7 @@ module Data.Text.Utf8.BoyerMoore.Searcher
     ( Searcher
     , automata
     , build
+    , buildNeedleIdSearcher
     , buildWithValues
     , containsAll
     , containsAny
@@ -102,13 +103,19 @@ containsAny !searcher !text =
     f _acc _match = BoyerMoore.Done True
   in
     any (\(automaton, ()) -> BoyerMoore.runText False f automaton text) (automata searcher)
+-- | Build a 'Searcher' that returns the needle's index in the needle list when it matches.
+
+buildNeedleIdSearcher :: [Text] -> Searcher Int
+buildNeedleIdSearcher !ns =
+  buildWithValues $ zip ns [0..]
 
 -- | Like 'containsAny', but checks whether all needles match instead.
+-- Use 'buildNeedleIdSearcher' to get an appropriate 'Searcher'.
 {-# NOINLINE containsAll #-}
-containsAll :: Searcher () -> Text -> Bool
+containsAll :: Searcher Int -> Text -> Bool
 containsAll !searcher !text =
   let
     -- On the first match, return True immediately.
     f _acc _match = BoyerMoore.Done True
   in
-    all (\(automaton, ()) -> BoyerMoore.runText False f automaton text) (automata searcher)
+    all (\(automaton, _) -> BoyerMoore.runText False f automaton text) (automata searcher)

--- a/tests/Data/Text/BoyerMooreSpec.hs
+++ b/tests/Data/Text/BoyerMooreSpec.hs
@@ -233,7 +233,7 @@ spec = parallel $ modifyMaxSuccess (const 200) $ do
     describe "containsAll" $ do
       prop "is equivalent to conjunction of Text.isInfixOf calls*" $ \ (needles :: [Text]) (haystack :: Text) ->
         let
-          searcher = Searcher.build CaseSensitive needles
+          searcher = Searcher.buildNeedleIdSearcher CaseSensitive needles
           test needle =
             not (Text.null needle) && needle `Text.isInfixOf` haystack
         in

--- a/tests/Data/Text/Utf8/BoyerMooreSpec.hs
+++ b/tests/Data/Text/Utf8/BoyerMooreSpec.hs
@@ -255,7 +255,7 @@ spec = parallel $ modifyMaxSuccess (const 200) $ do
     describe "containsAll" $ do
       prop "is equivalent to conjunction of Text.isInfixOf calls*" $ \ (needles :: [Text]) (haystack :: Text) ->
         let
-          searcher = Searcher.build needles
+          searcher = Searcher.buildNeedleIdSearcher needles
           test needle =
             not (Text.null needle) && needle `Text.isInfixOf` haystack
         in


### PR DESCRIPTION
Boyer-Moore `containsAll` functions now use a `Searcher Int` instead of a `Searcher ()`. This makes their interface consistent with the Aho-Corasick `containsAll` functions.