### PR TITLE
Make UTF-16 Boyer-Moore containsAll mind its CaseSensitivity

### DIFF
--- a/src/Data/Text/BoyerMoore/Searcher.hs
+++ b/src/Data/Text/BoyerMoore/Searcher.hs
@@ -138,4 +138,8 @@ containsAll !searcher !text =
     -- On the first match, return True immediately.
     f _acc _match = BoyerMoore.Done True
   in
-    all (\(automaton, _) -> BoyerMoore.runText False f automaton text) (automata searcher)
+    case caseSensitivity searcher of
+      CaseSensitive ->
+        all (\(automaton, _) -> BoyerMoore.runText False f automaton text) (automata searcher)
+      IgnoreCase ->
+        all (\(automaton, _) -> BoyerMoore.runLower False f automaton text) (automata searcher)

--- a/tests/Data/Text/BoyerMooreSpec.hs
+++ b/tests/Data/Text/BoyerMooreSpec.hs
@@ -231,6 +231,7 @@ spec = parallel $ modifyMaxSuccess (const 200) $ do
           Searcher.containsAny searcher haystack `shouldBe` any test needles
 
     describe "containsAll" $ do
+
       prop "is equivalent to conjunction of Text.isInfixOf calls*" $ \ (needles :: [Text]) (haystack :: Text) ->
         let
           searcher = Searcher.buildNeedleIdSearcher CaseSensitive needles
@@ -239,3 +240,12 @@ spec = parallel $ modifyMaxSuccess (const 200) $ do
         in
           Searcher.containsAll searcher haystack `shouldBe` all test needles
 
+      prop "performs case-insensitive search as well" $ \ (needles :: [Text]) (haystack :: Text) ->
+        let
+          lowerNeedles = map Utf16.lowerUtf16 needles
+          lowerHaystack = Utf16.lowerUtf16 haystack
+          searcher = Searcher.buildNeedleIdSearcher IgnoreCase lowerNeedles
+          test needle =
+            not (Text.null needle) && needle `Text.isInfixOf` lowerHaystack
+        in
+          Searcher.containsAll searcher haystack `shouldBe` all test lowerNeedles


### PR DESCRIPTION
When I implemented `containsAll` in #38, I accidentally made the UTF-16 version ignore the `CaseSensitivity` of the given `Searcher`. This PR addresses that problem and adds a test to check for it.