### PR TITLE
Release 1.1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.1.2.0 - "ByteArray Boogaloo" (2022-04-21)
+
+Added UTF-8 implementations on a mock `Text` type (in `Data.Text.Utf8`).
+
+- Added `Data.Text.Utf8*` modules
+- Moved `CaseSensitivity` to its own `Data.Text.CaseSensitivity` module.
+- Added the private module `Data.TypedByteArray` which contains thin wrappers over `ByteArray` and `MutableByteArray`.
+- Replaced uses of `Data.Vector.Unboxed.Vector` by `TypedByteArray`.
+
 ## v1.1.0.0 - "Moore Features" (2020-10-13)
 
 The most notable addition in this release is the implementation of the Boyer-Moore string search algorithm.

--- a/alfred-margaret.cabal
+++ b/alfred-margaret.cabal
@@ -1,5 +1,5 @@
 name:                alfred-margaret
-version:             1.1.1.0
+version:             1.1.2.0
 synopsis:            Fast Aho-Corasick string searching
 description:         An efficient implementation of the Aho-Corasick
                      string searching algorithm.
@@ -68,12 +68,11 @@ library
     , text             >= 1.2.3 && < 1.3
     , unordered-containers >= 0.2.9 && < 0.3
     , vector           >= 0.12 && < 0.13
-    -- TODO: Remove bytestring once we move to text-2.0
-    , bytestring
+    , bytestring       >= 0.10.12 && < 1
   ghc-options:         -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns -O2
   default-language:    Haskell2010
   if flag(aeson) {
-  build-depends:       aeson >= 1.4.2 && < 1.6
+  build-depends:       aeson >= 1.4.2 && < 3
   cpp-options:         -DHAS_AESON
   }
   if flag(llvm) {


### PR DESCRIPTION
I think we don't need to change anything but this, but you could check if Hackage accepts the version bounds (I used `cabal gen-bounds` and widened them to the next major versions).