### PR TITLE
Support updating replacements in AhoCorasick

### DIFF
--- a/src/Data/Text/AhoCorasick/Automaton.hs
+++ b/src/Data/Text/AhoCorasick/Automaton.hs
@@ -5,6 +5,7 @@
 -- repository root.
 
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -113,7 +114,7 @@ data AcMachine v = AcMachine
   -- ^ A lookup table for transitions from the root state, an optimization to
   -- avoid having to walk all transitions, at the cost of using a bit of
   -- additional memory.
-  } deriving (Generic)
+  } deriving (Generic, Functor)
 
 instance NFData v => NFData (AcMachine v)
 

--- a/src/Data/Text/AhoCorasick/Replacer.hs
+++ b/src/Data/Text/AhoCorasick/Replacer.hs
@@ -19,6 +19,7 @@ module Data.Text.AhoCorasick.Replacer
     , Replacer (..)
     , build
     , compose
+    , mapReplacement
     , run
     , runWithLimit
     ) where
@@ -33,13 +34,13 @@ import GHC.Generics (Generic)
 import qualified Data.Aeson as AE
 #endif
 
+import Data.Text.AhoCorasick.Searcher (Searcher)
 import Data.Text.CaseSensitivity (CaseSensitivity (..))
 import Data.Text.Utf8 (CodeUnitIndex, Text)
-import Data.Text.AhoCorasick.Searcher (Searcher)
 
-import qualified Data.Text.Utf8 as Utf8
 import qualified Data.Text.AhoCorasick.Automaton as Aho
 import qualified Data.Text.AhoCorasick.Searcher as Searcher
+import qualified Data.Text.Utf8 as Utf8
 
 -- | Descriptive type alias for strings to search for.
 type Needle = Text
@@ -115,6 +116,13 @@ compose (Replacer case1 searcher1) (Replacer case2 searcher2)
       in
         Just $ Replacer case1 searcher
 
+-- | Modify the replacement of a replacer. It doesn't modify the needles.
+mapReplacement :: (Replacement -> Replacement) -> Replacer -> Replacer
+mapReplacement f replacer = replacer{
+  replacerSearcher = Searcher.mapSearcher
+    (\p -> p {needleReplacement = f (needleReplacement p)})
+    (replacerSearcher replacer)
+}
 -- A match collected while running replacements. It is isomorphic to the Match
 -- reported by the automaton, but the data is arranged in a more useful way:
 -- as the start index and length of the match, and the replacement.


### PR DESCRIPTION
Adds a way to update the replacement in `AhoCorasick` replacers. This could be used to create a replacer where the needles remain constant, but the replacement text varies. 