### PR TITLE
Add missing DataKinds language extension

### DIFF
--- a/src/Data/Text/Utf8.hs
+++ b/src/Data/Text/Utf8.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE BinaryLiterals #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}


### PR DESCRIPTION
Fixes a build error I encountered on ghc 9.2.2:

```sh
Configuring library for alfred-margaret-2.1.0.0..
Preprocessing library for alfred-margaret-2.1.0.0..
Building library for alfred-margaret-2.1.0.0..
[ 1 of 14] Compiling Data.Text.CaseSensitivity ( src/Data/Text/CaseSensitivity.hs, /home/hugo/repos/alfred-margaret/dist-newstyle/build/x86_64-linux/ghc-8.10.7/alfred-margaret-2.1.0.0/build/Data/Text/CaseSensitivity.o, /home/hugo/repos/alfred-margaret/dist-newstyle/build/x86_64-linux/ghc-8.10.7/alfred-margaret-2.1.0.0/build/Data/Text/CaseSensitivity.dyn_o )
[ 2 of 14] Compiling Data.Text.Utf8.Unlower ( src/Data/Text/Utf8/Unlower.hs, /home/hugo/repos/alfred-margaret/dist-newstyle/build/x86_64-linux/ghc-8.10.7/alfred-margaret-2.1.0.0/build/Data/Text/Utf8/Unlower.o, /home/hugo/repos/alfred-margaret/dist-newstyle/build/x86_64-linux/ghc-8.10.7/alfred-margaret-2.1.0.0/build/Data/Text/Utf8/Unlower.dyn_o )
[ 3 of 14] Compiling Data.Text.Utf8   ( src/Data/Text/Utf8.hs, /home/hugo/repos/alfred-margaret/dist-newstyle/build/x86_64-linux/ghc-8.10.7/alfred-margaret-2.1.0.0/build/Data/Text/Utf8.o, /home/hugo/repos/alfred-margaret/dist-newstyle/build/x86_64-linux/ghc-8.10.7/alfred-margaret-2.1.0.0/build/Data/Text/Utf8.dyn_o )

src/Data/Text/Utf8.hs:111:29: error:
    • Data constructor ‘[]’ cannot be used here
        (perhaps you intended to use DataKinds)
    • In the first argument of ‘Exts.TupleRep’, namely
        ‘([] @Exts.RuntimeRep)’
      In the first argument of ‘(#,#)’, namely
        ‘(Exts.TupleRep ([] @Exts.RuntimeRep))’
      In an expression type signature:
        forall (s :: TYPE Exts.LiftedRep).
        Exts.MutableByteArray# s
        -> Exts.Int#
           -> Exts.State# s
              -> (#,#) @(Exts.TupleRep ([] @Exts.RuntimeRep)) @Exts.LiftedRep (Exts.State# s) CodeUnitIndex
      When typechecking the code for ‘Data.Primitive.Types.readByteArray#’
        in a derived instance for ‘Prim CodeUnitIndex’:
        To see the code I am typechecking, use -ddump-deriv
    |
111 |     deriving newtype (Show, Prim, Hashable, Num, NFData, FromJSON, ToJSON)
```

(I'm a little surprised that this was not could by the CI, could it be that I missed some steps on my end?)