### PR TITLE
Attempt to build a release version of `libacbench` on `stack-shell.nix`

### DIFF
--- a/stack-shell.nix
+++ b/stack-shell.nix
@@ -2,6 +2,15 @@
 let
   pkgs = import ./nix/nixpkgs-pinned.nix {};
   haskellDependencies = import ./nix/haskell-dependencies.nix;
+
+  libacbench = pkgs.rustPlatform.buildRustPackage rec {
+    name = "libacbench";
+    src = ./benchmark/rust-ffi/libacbench;
+    buildType = "release";
+    cargoLock = {
+      lockFile = ./benchmark/rust-ffi/libacbench/Cargo.lock;
+    };
+  };
 in
   pkgs.haskell.lib.buildStackProject {
     name = "alfred-margaret";
@@ -9,5 +18,6 @@ in
     buildInputs = with pkgs; [
       llvm_9
       zlib
+      libacbench
     ];
   }


### PR DESCRIPTION
If the user enters a nix-shell and tries to `stack build`, they might be met with:

```
Building all executables for `ac-bench-ffi' once. After a successful build of all of them, only specified executables will be rebuilt.
ac-bench-ffi> configure (lib + exe)
ac-bench-ffi> Configuring ac-bench-ffi-0...
ac-bench-ffi> Warning: 'extra-lib-dirs: libacbench/target/release' directory does not exist.
ac-bench-ffi> Cabal-simple_mPHDZzAJ_3.4.1.0_ghc-9.0.2: Missing dependency on a foreign
ac-bench-ffi> library:
ac-bench-ffi> * Missing (or bad) C library: libacbench
```

The fix for that, as indicated in [benchmark/README.md](benchmark/README.md) is to go into `benchmark/rust-ffi/libacbench` and run `cargo build --release`. This PR attempts to do that by default, stopping the user from is a simple attempt to package and build `libacbench` into our `default.nix`.