### PR TITLE
Allow using primitive < 0.9 and vector < 0.14

### DIFF
--- a/alfred-margaret.cabal
+++ b/alfred-margaret.cabal
@@ -61,10 +61,10 @@ library
     , containers       >= 0.6 && < 0.7
     , deepseq          >= 1.4 && < 1.5
     , hashable         >= 1.4.0.2 && < 1.5
-    , primitive        >= 0.6.4 && < 0.8
+    , primitive        >= 0.6.4 && < 0.9
     , text             >= 2.0 && < 2.1
     , unordered-containers >= 0.2.9 && < 0.3
-    , vector           >= 0.12 && < 0.13
+    , vector           >= 0.12 && < 0.14
   ghc-options:         -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns -O2
   default-language:    Haskell2010
   if flag(aeson) {


### PR DESCRIPTION
Tested with `GHC-9.0.2`