### PR TITLE
Bump dependencies for `alfred-margaret`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v2.1.0.1 - "Higher bounds!" (2024-09-05)
+
+Tested on GHC 9.6.6.
+
+- Revise dependency bounds ([#62](https://github.com/channable/alfred-margaret/issues/62) thanks @Bodigrim)
+- Allow using primitive < 0.9 and vector < 0.14 ([#59](https://github.com/channable/alfred-margaret/pull/59) thanks @rampion)
+
 ## v2.1.0.0 - "All The Cases!" (2022-08-31)
 
 - Added a case-insensitive variant of the Boyer-Moore algorithm in the `Data.Text.BoyerMooreCI.*` modules. ([#47](https://github.com/channable/alfred-margaret/pull/47))

--- a/alfred-margaret.cabal
+++ b/alfred-margaret.cabal
@@ -21,6 +21,8 @@ tested-with:
                    , GHC == 8.10.7
                      -- Nixpkgs unstable (Updated 2022-04-14)
                    , GHC == 9.0.2
+                     -- Nixpkgs unstable (Updated 2024-09-05)
+                   , GHC == 9.6.6
 
 source-repository head
   type:     git
@@ -58,11 +60,11 @@ library
                      , Data.TypedByteArray
   build-depends:
       base             >= 4.7 && < 5
-    , containers       >= 0.6 && < 0.7
-    , deepseq          >= 1.4 && < 1.5
-    , hashable         >= 1.4.0.2 && < 1.5
-    , primitive        >= 0.6.4 && < 0.9
-    , text             >= 2.0 && < 2.1
+    , containers       >= 0.6 && < 0.8
+    , deepseq          >= 1.4 && < 1.6
+    , hashable         >= 1.4.0.2 && < 1.6
+    , primitive        >= 0.6.4 && < 0.10
+    , text             >= 2.0 && < 2.2
     , unordered-containers >= 0.2.9 && < 0.3
     , vector           >= 0.12 && < 0.14
   ghc-options:         -Wall -Wincomplete-record-updates -Wincomplete-uni-patterns -O2

--- a/default.nix
+++ b/default.nix
@@ -18,14 +18,14 @@ let
       stack
 
       # Haskell dependencies
-      (ghc902Packages.ghcWithPackages haskellDependencies)
+      (ghc966Packages.ghcWithPackages haskellDependencies)
 
       # Other
-      llvm_9
+      llvm_13
     ] ++
     # We don't use the overlay here because the tooling doesn't need it.
     # The advantage of doing so is that these packages are already available in a global cache.
-    lib.optionals hsTools (with haskell.packages.ghc902; [
+    lib.optionals hsTools (with haskell.packages.ghc966; [
       haskell-language-server
       implicit-hie
     ]) ++

--- a/nix/ghc966-overlay.nix
+++ b/nix/ghc966-overlay.nix
@@ -2,5 +2,5 @@ self: super:
 let
   haskellOverlay = import ./haskell-overlay.nix;
 in {
-  ghc902Packages = super.haskell.packages.ghc902.extend haskellOverlay;
+  ghc966Packages = super.haskell.packages.ghc966.extend haskellOverlay;
 }

--- a/nix/haskell-overlay.nix
+++ b/nix/haskell-overlay.nix
@@ -1,5 +1,3 @@
 self: super: {
-  hashable = self.hashable_1_4_0_2;
-  parsec = self.parsec_3_1_15_0;
-  text = self.text_2_0;
+
 }

--- a/nix/nixpkgs-pinned.nix
+++ b/nix/nixpkgs-pinned.nix
@@ -3,5 +3,5 @@ let
   sources = import ./sources.nix;
 in
   import sources.nixpkgs {
-    overlays = [(import ./ghc902-overlay.nix)] ++ overlays;
+    overlays = [(import ./ghc966-overlay.nix)] ++ overlays;
   }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0343e3415784b2cd9c68924294794f7dbee12ab3",
-        "sha256": "0ypgcim0vbv2742m7rb1010ga4zlayvpdma5qqw13brp8q5vjvcy",
+        "rev": "b833ff01a0d694b910daca6e2ff4a3f26dee478c",
+        "sha256": "1v3y9km48glcmgzk7h8s9sg5sgv1w86pyad973d981sk84a85cdl",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/0343e3415784b2cd9c68924294794f7dbee12ab3.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/b833ff01a0d694b910daca6e2ff4a3f26dee478c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "5e7fb7699c84da3420495e40459dfbff459c16e4"
     }

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -31,8 +31,10 @@ let
           if spec ? branch then "refs/heads/${spec.branch}" else
             if spec ? tag then "refs/tags/${spec.tag}" else
               abort "In git source '${name}': Please specify `ref`, `tag` or `branch`!";
+      submodules = if spec ? submodules then spec.submodules else false;
     in
-      builtins.fetchGit { url = spec.repo; inherit (spec) rev; inherit ref; };
+      builtins.fetchGit { url = spec.repo; inherit (spec) rev; inherit ref; }
+      // (if builtins.compareVersions builtins.nixVersion "2.4" >= 0 then { inherit submodules; } else {});
 
   fetch_local = spec: spec.path;
 

--- a/stack-shell.nix
+++ b/stack-shell.nix
@@ -14,9 +14,9 @@ let
 in
   pkgs.haskell.lib.buildStackProject {
     name = "alfred-margaret";
-    ghc = pkgs.ghc902Packages.ghcWithPackages haskellDependencies;
+    ghc = pkgs.ghc966Packages.ghcWithPackages haskellDependencies;
     buildInputs = with pkgs; [
-      llvm_9
+      llvm_13
       zlib
       libacbench
     ];

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: ghc-9.0.2
+resolver: ghc-9.6.6
 packages:
 - .
 - benchmark/haskell


### PR DESCRIPTION
XRef: https://github.com/channable/alfred-margaret/issues/62

I took the liberty to also update our other dependencies:

* GHC compiler 9.0.2 -> 9.6.6
* LLVM version 9 -> 13, [the LLVM version should be between 13 and 16 for GHC 9.6.6](https://downloads.haskell.org/ghc/9.6.6/docs/users_guide/codegens.html#llvm-code-generator-fllvm)