### PR TITLE
Upgrade Semaphore CI image to 22.04

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -4,7 +4,7 @@ name: "Semaphore pipeline for alfred-margaret"
 agent:
   machine:
     type: f1-standard-2
-    os_image: ubuntu2004
+    os_image: ubuntu2204
 
 # Automatically cancel jobs that are already running for all branches but master
 auto_cancel:


### PR DESCRIPTION
## Description

Part of [#12385](https://github.com/https://github.com/channable/devops/issues/12385)
Upgrades Semaphore CI image from 20.04 to 22.04