### PR TITLE
Add `direnv` support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,25 @@
+# shellcheck disable=SC2148 # .envrc files need no shell directive
+
+# NOTE: This file is based on https://github.com/channable/repository-template/blob/master/.envrc
+# When making edits that apply to other repositories, please update the file there.
+
+# Add possibility to run a custom envrc that completely overrides the behavior of this envrc.
+CUSTOM_ENVRC=.customenvrc
+if [ -f "$CUSTOM_ENVRC" ]; then
+  echo "Using .customenvrc file"
+  source_env $CUSTOM_ENVRC
+else
+  # Decrease logging output
+  # shellcheck disable=SC2034 # unused variable is still read by direnv.
+  DIRENV_LOG_FORMAT=
+  # Install nix-direnv, which has an improved implementation of `use nix` that
+  # caches the Nix environment. Note that this URL is cached locally, so it
+  # doesn't fetch the script every time.
+  if ! has nix_direnv_version || ! nix_direnv_version 3.0.4; then
+    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.4/direnvrc" "sha256-DzlYZ33mWF/Gs8DDeyjr8mnVmQGx7ASYqA5WlxwvBG4="
+  fi
+
+  watch_file ./nix/**/*.nix ./nix/sources.json
+
+  use nix default.nix --argstr environment shell
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Direnv cache
+/.direnv/
+
 # Stack build directory.
 /.stack-work/
 

--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,10 @@
   # Use haskell-languager-server?
   hsTools ? false,
   # Use tools for the benchmarks in other languages (Cargo, Bazel, etc.)?
-  benchTools ? false
+  benchTools ? false,
+  # Which environment to build. Use "shell" for direnv/nix-shell, "build-env"
+  # for the legacy buildEnv derivation.
+  environment ? "build-env"
 }:
 let
   haskellDependencies = import ./nix/haskell-dependencies.nix;
@@ -46,8 +49,16 @@ let
       gmp
     ]
   );
+
+  environments = {
+    build-env = pkgs.buildEnv {
+      name = "alfred-margaret-env";
+      paths = paths;
+    };
+
+    shell = pkgs.mkShell {
+      buildInputs = paths;
+    };
+  };
 in
-  pkgs.buildEnv {
-    name = "alfred-margaret-env";
-    paths = paths;
-  }
+  environments."${environment}"

--- a/default.nix
+++ b/default.nix
@@ -25,6 +25,7 @@ let
 
       # Other
       llvm_19
+      llvmPackages_19.clang
     ] ++
     # We don't use the overlay here because the tooling doesn't need it.
     # The advantage of doing so is that these packages are already available in a global cache.

--- a/stack-shell.nix
+++ b/stack-shell.nix
@@ -17,6 +17,7 @@ in
     ghc = pkgs.ghc910Packages.ghcWithPackages haskellDependencies;
     buildInputs = with pkgs; [
       llvm_19
+      llvmPackages_19.clang
       zlib
       libacbench
     ];


### PR DESCRIPTION
This adds the required `.envrc` file and modifies the `default.nix` to expose a shell.

The shell didn't work locally because I don't have clang installed, we now also expose it via the nix environment.