### PR TITLE
Update: `GHC910` -> `GHC 914`

### DIFF
--- a/alfred-margaret.cabal
+++ b/alfred-margaret.cabal
@@ -60,7 +60,7 @@ library
   other-modules:       Data.Primitive.Extended
   build-depends:
       base             >= 4.7 && < 5
-    , containers       >= 0.6 && < 0.8
+    , containers       >= 0.6 && < 0.9
     , deepseq          >= 1.4 && < 1.6
     , hashable         >= 1.4.0.2 && < 1.6
     , primitive        >= 0.6.4 && < 0.10

--- a/default.nix
+++ b/default.nix
@@ -11,6 +11,8 @@
 let
   haskellDependencies = import ./nix/haskell-dependencies.nix;
 
+  glibcLocalesMinimal = import ./nix/locale.nix { inherit pkgs; };
+
   paths = with pkgs; (
     [
       # Nix tooling
@@ -58,7 +60,10 @@ let
     };
 
     shell = pkgs.mkShell {
-      buildInputs = paths;
+      buildInputs = paths ++ [ glibcLocalesMinimal ];
+
+      LOCALE_ARCHIVE = "${glibcLocalesMinimal}/lib/locale/locale-archive";
+      LANG = "C.UTF-8";
     };
   };
 in

--- a/default.nix
+++ b/default.nix
@@ -21,7 +21,7 @@ let
       stack
 
       # Haskell dependencies
-      (ghc910Packages.ghcWithPackages haskellDependencies)
+      (ghc914Packages.ghcWithPackages haskellDependencies)
 
       # Other
       llvm_19
@@ -29,7 +29,7 @@ let
     ] ++
     # We don't use the overlay here because the tooling doesn't need it.
     # The advantage of doing so is that these packages are already available in a global cache.
-    lib.optionals hsTools (with haskell.packages.ghc910; [
+    lib.optionals hsTools (with haskell.packages.ghc914; [
       haskell-language-server
       implicit-hie
     ]) ++

--- a/nix/ghc914-overlay.nix
+++ b/nix/ghc914-overlay.nix
@@ -2,5 +2,5 @@ self: super:
 let
   haskellOverlay = import ./haskell-overlay.nix;
 in {
-  ghc910Packages = super.haskell.packages.ghc910.extend haskellOverlay;
+  ghc914Packages = super.haskell.packages.ghc914.extend haskellOverlay;
 }

--- a/nix/haskell-overlay.nix
+++ b/nix/haskell-overlay.nix
@@ -1,3 +1,7 @@
-self: super: {
-
+self: super:
+let
+  hlib = (import ./nixpkgs-pinned.nix {}).haskell.lib;
+in {
+  binary-orphans = hlib.doJailbreak super.binary-orphans;
+  microstache = hlib.doJailbreak super.microstache;
 }

--- a/nix/locale.nix
+++ b/nix/locale.nix
@@ -1,0 +1,5 @@
+{ pkgs }:
+pkgs.glibcLocales.override {
+  allLocales = false;
+  locales = [ "C.UTF-8/UTF-8" ];
+}

--- a/nix/nixpkgs-pinned.nix
+++ b/nix/nixpkgs-pinned.nix
@@ -3,5 +3,5 @@ let
   sources = import ./sources.nix;
 in
   import sources.nixpkgs {
-    overlays = [(import ./ghc910-overlay.nix)] ++ overlays;
+    overlays = [(import ./ghc914-overlay.nix)] ++ overlays;
   }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13b0f9e6ac78abbbb736c635d87845c4f4bee51b",
-        "sha256": "0js8a1abl5mi1j0l9wiasis8srm1a7wjrd3scwb8xpq3i0amvz8r",
+        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
+        "sha256": "19mppaiq05h4xrpch4i0jkkca4nnfdksc2fkhssplawggsj57id6",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/13b0f9e6ac78abbbb736c635d87845c4f4bee51b.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/566acc07c54dc807f91625bb286cb9b321b5f42a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "5e7fb7699c84da3420495e40459dfbff459c16e4"
     }

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -10,31 +10,50 @@ let
     let
       name' = sanitizeName name + "-src";
     in
-      if spec.builtin or true then
-        builtins_fetchurl { inherit (spec) url sha256; name = name'; }
-      else
-        pkgs.fetchurl { inherit (spec) url sha256; name = name'; };
+    if spec.builtin or true then
+      builtins_fetchurl { inherit (spec) url sha256; name = name'; }
+    else
+      pkgs.fetchurl { inherit (spec) url sha256; name = name'; };
 
   fetch_tarball = pkgs: name: spec:
     let
       name' = sanitizeName name + "-src";
     in
-      if spec.builtin or true then
-        builtins_fetchTarball { name = name'; inherit (spec) url sha256; }
-      else
-        pkgs.fetchzip { name = name'; inherit (spec) url sha256; };
+    if spec.builtin or true then
+      builtins_fetchTarball { name = name'; inherit (spec) url sha256; }
+    else
+      pkgs.fetchzip { name = name'; inherit (spec) url sha256; };
 
   fetch_git = name: spec:
     let
       ref =
-        if spec ? ref then spec.ref else
+        spec.ref or (
           if spec ? branch then "refs/heads/${spec.branch}" else
-            if spec ? tag then "refs/tags/${spec.tag}" else
-              abort "In git source '${name}': Please specify `ref`, `tag` or `branch`!";
-      submodules = if spec ? submodules then spec.submodules else false;
+          if spec ? tag then "refs/tags/${spec.tag}" else
+          abort "In git source '${name}': Please specify `ref`, `tag` or `branch`!"
+        );
+      submodules = spec.submodules or false;
+      submoduleArg =
+        let
+          nixSupportsSubmodules = builtins.compareVersions builtins.nixVersion "2.4" >= 0;
+          emptyArgWithWarning =
+            if submodules
+            then
+              builtins.trace
+                (
+                  "The niv input \"${name}\" uses submodules "
+                  + "but your nix's (${builtins.nixVersion}) builtins.fetchGit "
+                  + "does not support them"
+                )
+                { }
+            else { };
+        in
+        if nixSupportsSubmodules
+        then { inherit submodules; }
+        else emptyArgWithWarning;
     in
-      builtins.fetchGit { url = spec.repo; inherit (spec) rev; inherit ref; }
-      // (if builtins.compareVersions builtins.nixVersion "2.4" >= 0 then { inherit submodules; } else {});
+    builtins.fetchGit
+      ({ url = spec.repo; inherit (spec) rev; inherit ref; } // submoduleArg);
 
   fetch_local = spec: spec.path;
 
@@ -68,16 +87,16 @@ let
       hasNixpkgsPath = builtins.any (x: x.prefix == "nixpkgs") builtins.nixPath;
       hasThisAsNixpkgsPath = <nixpkgs> == ./.;
     in
-      if builtins.hasAttr "nixpkgs" sources
-      then sourcesNixpkgs
-      else if hasNixpkgsPath && ! hasThisAsNixpkgsPath then
-        import <nixpkgs> {}
-      else
-        abort
-          ''
-            Please specify either <nixpkgs> (through -I or NIX_PATH=nixpkgs=...) or
-            add a package called "nixpkgs" to your sources.json.
-          '';
+    if builtins.hasAttr "nixpkgs" sources
+    then sourcesNixpkgs
+    else if hasNixpkgsPath && ! hasThisAsNixpkgsPath then
+      import <nixpkgs> { }
+    else
+      abort
+        ''
+          Please specify either <nixpkgs> (through -I or NIX_PATH=nixpkgs=...) or
+          add a package called "nixpkgs" to your sources.json.
+        '';
 
   # The actual fetching function.
   fetch = pkgs: name: spec:
@@ -97,13 +116,13 @@ let
   # the path directly as opposed to the fetched source.
   replace = name: drv:
     let
-      saneName = stringAsChars (c: if isNull (builtins.match "[a-zA-Z0-9]" c) then "_" else c) name;
+      saneName = stringAsChars (c: if (builtins.match "[a-zA-Z0-9]" c) == null then "_" else c) name;
       ersatz = builtins.getEnv "NIV_OVERRIDE_${saneName}";
     in
-      if ersatz == "" then drv else
-        # this turns the string into an actual Nix path (for both absolute and
-        # relative paths)
-        if builtins.substring 0 1 ersatz == "/" then /. + ersatz else /. + builtins.getEnv "PWD" + "/${ersatz}";
+    if ersatz == "" then drv else
+      # this turns the string into an actual Nix path (for both absolute and
+      # relative paths)
+    if builtins.substring 0 1 ersatz == "/" then /. + ersatz else /. + builtins.getEnv "PWD" + "/${ersatz}";
 
   # Ports of functions for older nix versions
 
@@ -114,7 +133,7 @@ let
   );
 
   # https://github.com/NixOS/nixpkgs/blob/0258808f5744ca980b9a1f24fe0b1e6f0fecee9c/lib/lists.nix#L295
-  range = first: last: if first > last then [] else builtins.genList (n: first + n) (last - first + 1);
+  range = first: last: if first > last then [ ] else builtins.genList (n: first + n) (last - first + 1);
 
   # https://github.com/NixOS/nixpkgs/blob/0258808f5744ca980b9a1f24fe0b1e6f0fecee9c/lib/strings.nix#L257
   stringToCharacters = s: map (p: builtins.substring p 1 s) (range 0 (builtins.stringLength s - 1));
@@ -125,43 +144,46 @@ let
   concatStrings = builtins.concatStringsSep "";
 
   # https://github.com/NixOS/nixpkgs/blob/8a9f58a375c401b96da862d969f66429def1d118/lib/attrsets.nix#L331
-  optionalAttrs = cond: as: if cond then as else {};
+  optionalAttrs = cond: as: if cond then as else { };
 
   # fetchTarball version that is compatible between all the versions of Nix
   builtins_fetchTarball = { url, name ? null, sha256 }@attrs:
     let
       inherit (builtins) lessThan nixVersion fetchTarball;
     in
-      if lessThan nixVersion "1.12" then
-        fetchTarball ({ inherit url; } // (optionalAttrs (!isNull name) { inherit name; }))
-      else
-        fetchTarball attrs;
+    if lessThan nixVersion "1.12" then
+      fetchTarball ({ inherit url; } // (optionalAttrs (name != null) { inherit name; }))
+    else
+      fetchTarball attrs;
 
   # fetchurl version that is compatible between all the versions of Nix
   builtins_fetchurl = { url, name ? null, sha256 }@attrs:
     let
       inherit (builtins) lessThan nixVersion fetchurl;
     in
-      if lessThan nixVersion "1.12" then
-        fetchurl ({ inherit url; } // (optionalAttrs (!isNull name) { inherit name; }))
-      else
-        fetchurl attrs;
+    if lessThan nixVersion "1.12" then
+      fetchurl ({ inherit url; } // (optionalAttrs (name != null) { inherit name; }))
+    else
+      fetchurl attrs;
 
   # Create the final "sources" from the config
   mkSources = config:
-    mapAttrs (
-      name: spec:
-        if builtins.hasAttr "outPath" spec
-        then abort
-          "The values in sources.json should not have an 'outPath' attribute"
-        else
-          spec // { outPath = replace name (fetch config.pkgs name spec); }
-    ) config.sources;
+    mapAttrs
+      (
+        name: spec:
+          if builtins.hasAttr "outPath" spec
+          then
+            abort
+              "The values in sources.json should not have an 'outPath' attribute"
+          else
+            spec // { outPath = replace name (fetch config.pkgs name spec); }
+      )
+      config.sources;
 
   # The "config" used by the fetchers
   mkConfig =
     { sourcesFile ? if builtins.pathExists ./sources.json then ./sources.json else null
-    , sources ? if isNull sourcesFile then {} else builtins.fromJSON (builtins.readFile sourcesFile)
+    , sources ? if sourcesFile == null then { } else builtins.fromJSON (builtins.readFile sourcesFile)
     , system ? builtins.currentSystem
     , pkgs ? mkPkgs sources system
     }: rec {
@@ -173,4 +195,4 @@ let
     };
 
 in
-mkSources (mkConfig {}) // { __functor = _: settings: mkSources (mkConfig settings); }
+mkSources (mkConfig { }) // { __functor = _: settings: mkSources (mkConfig settings); }

--- a/stack-shell.nix
+++ b/stack-shell.nix
@@ -14,7 +14,7 @@ let
 in
   pkgs.haskell.lib.buildStackProject {
     name = "alfred-margaret";
-    ghc = pkgs.ghc910Packages.ghcWithPackages haskellDependencies;
+    ghc = pkgs.ghc914Packages.ghcWithPackages haskellDependencies;
     buildInputs = with pkgs; [
       llvm_19
       llvmPackages_19.clang

--- a/stack-shell.nix
+++ b/stack-shell.nix
@@ -3,6 +3,8 @@ let
   pkgs = import ./nix/nixpkgs-pinned.nix {};
   haskellDependencies = import ./nix/haskell-dependencies.nix;
 
+  glibcLocalesMinimal = import ./nix/locale.nix { inherit pkgs; };
+
   libacbench = pkgs.rustPlatform.buildRustPackage rec {
     name = "libacbench";
     src = ./benchmark/rust-ffi/libacbench;
@@ -12,13 +14,17 @@ let
     };
   };
 in
-  pkgs.haskell.lib.buildStackProject {
+  pkgs.mkShell {
     name = "alfred-margaret";
-    ghc = pkgs.ghc914Packages.ghcWithPackages haskellDependencies;
-    buildInputs = with pkgs; [
-      llvm_19
-      llvmPackages_19.clang
-      zlib
+    buildInputs = [
+      (pkgs.ghc914Packages.ghcWithPackages haskellDependencies)
+      pkgs.llvm_19
+      pkgs.llvmPackages_19.clang
+      pkgs.zlib
+      glibcLocalesMinimal
       libacbench
     ];
+
+    LOCALE_ARCHIVE = "${glibcLocalesMinimal}/lib/locale/locale-archive";
+    LANG = "C.UTF-8";
   }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: ghc-9.10
+resolver: ghc-9.14
 packages:
 - .
 - benchmark/haskell


### PR DESCRIPTION
Closes: https://github.com/channable/alfred-margaret/issues/70

See https://github.com/channable/alfred-margaret/pull/73 to run `cabal outdated` on our side (we normally only pull in dependencies via Nix)

---

This updates Nix to run `alfred-margaret` using `GHC914`.
This extends the bounds of containers to allow version `0.8`.
Required changes also include jailbreaking two packages and exposing the right locales for the tests.