### PR TITLE
Cachix: Push nix environment to `channable-public`

### DIFF
--- a/.semaphore/push-to-cachix.sh
+++ b/.semaphore/push-to-cachix.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Build the alfred-margaret Nix environment and push it (together with all
+# of its build-time and runtime requisites) to the `channable-public`
+# Cachix cache.
+#
+# Requires `CACHIX_SIGNING_KEY` to be set in the environment (CI exposes it
+# as a secret).
+#
+# Usage:
+#   ./.semaphore/push-to-cachix.sh
+set -euo pipefail
+
+# 1. Build both environments (no GC root) and capture their output paths.
+outputs=$(
+  nix build -f default.nix --no-link --print-out-paths --argstr environment build-env
+  nix build -f default.nix --no-link --print-out-paths --argstr environment shell
+)
+
+# 2. Push all paths to cachix.
+echo "$outputs" | cachix push channable-public

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -11,6 +11,14 @@ auto_cancel:
   running:
     when: "branch != 'master'"
 
+# This configuration applies to all blocks.
+global_job_config:
+  # List secrets that are to be available in all jobs.
+  # Secrets can be created using the web interface, or by using the `sem` tool.
+  secrets:
+    # Keys needed to access our cachix cache.
+    - name: "cachix-channable-public"
+
 blocks:
   - name: Stack
     task:
@@ -50,6 +58,9 @@ blocks:
           # Fill caches
           - cache store home-stack-$SEMAPHORE_GIT_BRANCH ~/.stack
           - cache store stack-work-$SEMAPHORE_GIT_BRANCH .stack-work
+          # Push the Nix environment and all of its requisites to the
+          # `channable-public` Cachix cache.
+          - nix shell -f nix/nixpkgs-pinned.nix cachix -c ./.semaphore/push-to-cachix.sh
           # Store a copy of the nix store. This will be refreshed daily, which
           # is more than sufficient for this repo. Semaphore's cache is faster
           # than Cachix.

--- a/default.nix
+++ b/default.nix
@@ -18,6 +18,7 @@ let
       # Nix tooling
       niv
       nix-tree
+      cachix
 
       # Haskell tooling
       stack


### PR DESCRIPTION
Adds script to push all the prerequisites to our channable-public cache on Cachix.
Runs the script on CI to ensure our dev environments don't need to build the world.