### PR TITLE
Fix missing foldl' import in Automaton.hs (regression in 2.1.1.0)

### DIFF
--- a/src/Data/Text/AhoCorasick/Automaton.hs
+++ b/src/Data/Text/AhoCorasick/Automaton.hs
@@ -46,6 +46,7 @@ module Data.Text.AhoCorasick.Automaton
 import Control.DeepSeq (NFData)
 import Data.Bits (Bits (shiftL, shiftR, (.&.), (.|.)))
 import Data.Char (chr)
+import Data.Foldable (foldl')
 import Data.IntMap.Strict (IntMap)
 import Data.Primitive.Extended
   ( Prim


### PR DESCRIPTION
## Summary

`foldl'` was explicitly imported from `Data.Foldable` in `2.1.0.2` but this import was accidentally dropped in `2.1.1.0`. The call site at line ~292 uses it unqualified, which fails to compile on GHC 9.6 where `foldl'` is not re-exported via `Prelude` and `Data.List` is only in scope as `qualified ... as List`.

## Affected versions

- `2.1.1.0` — broken on GHC 9.6 (e.g. aarch64-linux)
- `2.1.0.2` — worked (had `import Data.Foldable (foldl')`)

## Fix

Add back the missing import:

```haskell
import Data.Foldable (foldl')
```

## Error observed

```
src/Data/Text/AhoCorasick/Automaton.hs:292:5: error:
    Variable not in scope: foldl'
    Suggested fix: use 'IntMap.foldl'' or 'Vector.foldl'' or 'Text.foldl''
```